### PR TITLE
EDU-103 Do a full page refresh (without using the cache) when home page is loaded from cache

### DIFF
--- a/src/components/pages/index.js
+++ b/src/components/pages/index.js
@@ -3,8 +3,8 @@ import PropTypes from 'prop-types';
 import DocView from '../doc-view.js';
 import { Button, Input } from 'antd';
 import SiteLogo from '../site-logo.js';
-import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import React, { useState, useEffect } from 'react';
 import { useService } from '../container-context.js';
 import { useLanguage } from '../language-context.js';
 import { getHomeUrl, getSearchUrl } from '../../utils/urls.js';
@@ -28,7 +28,7 @@ function Index({ initialState }) {
     }
   };
 
-  React.useEffect(() => {
+  useEffect(() => {
     window.addEventListener('pageshow', handlePageShow);
 
     return () => {

--- a/src/components/pages/index.js
+++ b/src/components/pages/index.js
@@ -22,6 +22,20 @@ function Index({ initialState }) {
   const currentHomeLanguage = homeLanguages[currentHomeLanguageIndex];
   const [isSearching, setIsSearching] = useState(false);
 
+  const handlePageShow = event => {
+    if (event.persisted) {
+      window.location.reload(true);
+    }
+  };
+
+  React.useEffect(() => {
+    window.addEventListener('pageshow', handlePageShow);
+
+    return () => {
+      window.removeEventListener('pageshow', handlePageShow);
+    };
+  }, []);
+
   const handleSearch = () => {
     setIsSearching(true);
     window.location = getSearchUrl(searchText.trim());


### PR DESCRIPTION
Closes https://educandu.atlassian.net/browse/EDU-103

This works in Chrome, Firefox and Safari on MacOS.