### PR TITLE
EDU-149 Improve UX on import pages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: "16.11.0"
+          node-version: "16.13.1"
           cache: "yarn"
       - name: Install node modules
         run: yarn install --non-interactive --check-files --frozen-lockfile
@@ -60,7 +60,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: "16.11.0"
+          node-version: "16.13.1"
           cache: "yarn"
       - name: Install node modules
         run: yarn install --non-interactive --check-files --frozen-lockfile
@@ -97,7 +97,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: "16.11.0"
+          node-version: "16.13.1"
           cache: "yarn"
       - name: Install node modules
         run: yarn install --non-interactive --check-files --frozen-lockfile

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "./*": "./dist/*"
   },
   "engines": {
-    "node": "^16.11.0"
+    "node": "^16.12.0"
   },
   "scripts": {
     "start": "gulp",

--- a/src/components/default-page-template.js
+++ b/src/components/default-page-template.js
@@ -100,7 +100,7 @@ function DefaultPageTemplate({ children, fullScreen, headerActions, alerts }) {
     pageMenuItems.push({
       key: 'import',
       href: urls.getImportsUrl(),
-      text: t('pageNames:importBatchCreation'),
+      text: t('pageNames:importBatches'),
       icon: ImportOutlined,
       permission: permissions.MANAGE_IMPORT
     });

--- a/src/components/document-import-table.js
+++ b/src/components/document-import-table.js
@@ -1,0 +1,146 @@
+import by from 'thenby';
+import PropTypes from 'prop-types';
+import { Tooltip, Table } from 'antd';
+import { useTranslation } from 'react-i18next';
+import { getArticleUrl } from '../utils/urls.js';
+import { useService } from './container-context.js';
+import { DOCUMENT_IMPORT_TYPE } from '../common/constants.js';
+import React, { useMemo, memo, useState, useEffect } from 'react';
+import { useDateFormat, useLanguage } from './language-context.js';
+import LanguageNameProvider from '../data/language-name-provider.js';
+import CountryFlagAndName from './localization/country-flag-and-name.js';
+import { CloudDownloadOutlined, CloudSyncOutlined } from '@ant-design/icons';
+
+const getImportTypeIcon = importType => {
+  switch (importType) {
+    case DOCUMENT_IMPORT_TYPE.add:
+      return <CloudDownloadOutlined />;
+    case DOCUMENT_IMPORT_TYPE.update:
+      return <CloudSyncOutlined />;
+    default:
+      throw new Error(`Invalid import type: '${importType}'`);
+  }
+};
+
+const getLanguageComponent = documentLanguageData => {
+  return <CountryFlagAndName code={documentLanguageData.flag} name={documentLanguageData.name} flagOnly />;
+};
+
+const getTooltipComponent = (importTypeIcon, importTypeTooltipText) => {
+  return <Tooltip className="DocumentImportTable-importTypeIcon" title={importTypeTooltipText}>{importTypeIcon}</Tooltip>;
+};
+
+const getTitleComponent = (title, url) => {
+  return url ? <a href={url} target="_blank" rel="noopener noreferrer" >{title}</a> : <span>{title}</span>;
+};
+
+function createRecords(importableDocuments, t, formatDate, languageNameProvider, language, importSourceBaseUrl) {
+  const languagesData = languageNameProvider.getData(language);
+
+  return importableDocuments.map(doc => {
+    const documentLanguageData = languagesData[doc.language];
+    const url = doc.slug ? `${importSourceBaseUrl}${getArticleUrl(doc.slug)}` : null;
+    const importTypeIcon = getImportTypeIcon(doc.importType);
+    const importTypeTooltipText = t(doc.importType);
+
+    return {
+      key: doc.key,
+      title: doc.title,
+      url,
+      titleComponent: getTitleComponent(doc.title, url),
+      language: doc.language,
+      languageLocalized: documentLanguageData.name,
+      languageComponent: getLanguageComponent(documentLanguageData),
+      updatedOn: doc.updatedOn,
+      updatedOnLocalized: formatDate(doc.updatedOn),
+      importType: doc.importType,
+      importTypeIcon,
+      importTypeTooltipText,
+      importTypeTooltipComponent: getTooltipComponent(importTypeIcon, importTypeTooltipText)
+    };
+  });
+}
+
+function DocumentImportTable({ importableDocuments, importSourceBaseUrl, loading, onSelectedKeysChange }) {
+  const { language } = useLanguage();
+  const { formatDate } = useDateFormat();
+  const [records, setRecords] = useState([]);
+  const { t } = useTranslation('documentImportTable');
+  const languageNameProvider = useService(LanguageNameProvider);
+
+  useEffect(() => {
+    setRecords(createRecords(importableDocuments, t, formatDate, languageNameProvider, language, importSourceBaseUrl));
+  }, [importableDocuments, t, formatDate, languageNameProvider, language, importSourceBaseUrl]);
+
+  const columns = useMemo(() => [
+    {
+      title: t('importType'),
+      key: 'importType',
+      width: '150px',
+      sorter: by(x => x.importType),
+      render: (_text, record) => record.importTypeTooltipComponent,
+      shouldCellUpdate: (record, prevRecord) => record.importType !== prevRecord.importType || record.importTypeTooltipText !== prevRecord.importTypeTooltipText
+    },
+    {
+      title: t('title'),
+      key: 'title',
+      sorter: by(x => x.title),
+      render: (_text, record) => record.titleComponent,
+      shouldCellUpdate: (record, prevRecord) => record.title !== prevRecord.title || record.url !== prevRecord.url
+    },
+    {
+      title: t('language'),
+      key: 'language',
+      width: '150px',
+      sorter: by(x => x.language),
+      render: (_text, record) => record.languageComponent,
+      shouldCellUpdate: (record, prevRecord) => record.language !== prevRecord.language || record.languageLocalized !== prevRecord.languageLocalized
+    },
+    {
+      title: t('updatedOn'),
+      key: 'updatedOn',
+      width: '200px',
+      sorter: by(x => x.updatedOn),
+      render: (_text, record) => record.updatedOnLocalized,
+      shouldCellUpdate: (record, prevRecord) => record.updatedOn !== prevRecord.updatedOn
+    }
+  ], [t]);
+
+  const tableRowSelection = useMemo(() => ({
+    type: 'checkbox',
+    onChange: onSelectedKeysChange
+  }), [onSelectedKeysChange]);
+
+  return (
+    <Table
+      bordered
+      size="small"
+      rowKey="key"
+      className="DocumentImportTable"
+      rowSelection={tableRowSelection}
+      columns={columns}
+      pagination={false}
+      dataSource={records}
+      loading={loading}
+      />
+  );
+}
+
+DocumentImportTable.propTypes = {
+  importSourceBaseUrl: PropTypes.string.isRequired,
+  importableDocuments: PropTypes.arrayOf(PropTypes.shape({
+    key: PropTypes.string.isRequired,
+    importType: PropTypes.string.isRequired,
+    title: PropTypes.string.isRequired,
+    language: PropTypes.string.isRequired,
+    updatedOn: PropTypes.string.isRequired
+  })).isRequired,
+  loading: PropTypes.bool,
+  onSelectedKeysChange: PropTypes.func.isRequired
+};
+
+DocumentImportTable.defaultProps = {
+  loading: false
+};
+
+export default memo(DocumentImportTable);

--- a/src/components/document-import-table.less
+++ b/src/components/document-import-table.less
@@ -1,0 +1,7 @@
+.DocumentImportTable {
+  display: block;
+}
+
+.DocumentImportTable-importTypeIcon {
+  font-size: 18px;
+}

--- a/src/components/document-import-table.yml
+++ b/src/components/document-import-table.yml
@@ -1,0 +1,12 @@
+importType:
+  en: Import type
+  de: Import-Typ
+title:
+  en: Title
+  de: Titel
+language:
+  en: Language
+  de: Sprache
+updatedOn:
+  en: Update date
+  de: Update-Datum

--- a/src/components/pages/import-batch-creation.js
+++ b/src/components/pages/import-batch-creation.js
@@ -1,42 +1,28 @@
-import by from 'thenby';
+import { Button } from 'antd';
 import PropTypes from 'prop-types';
-import { Tooltip, Button, Table } from 'antd';
 import { useTranslation } from 'react-i18next';
-import { useRequest } from '../request-context.js';
 import React, { useState, useEffect } from 'react';
 import { useService } from '../container-context.js';
 import { handleApiError } from '../../ui/error-helper.js';
 import ClientConfig from '../../bootstrap/client-config.js';
 import { useGlobalAlerts } from '../../ui/global-alerts.js';
 import { useReloadPersistedWindow } from '../../ui/hooks.js';
-import { DOCUMENT_IMPORT_TYPE } from '../../common/constants.js';
+import DocumentImportTable from '../document-import-table.js';
 import ImportApiClient from '../../services/import-api-client.js';
-import { useDateFormat, useLanguage } from '../language-context.js';
-import LanguageNameProvider from '../../data/language-name-provider.js';
-import CountryFlagAndName from '../localization/country-flag-and-name.js';
-import { CloudDownloadOutlined, CloudSyncOutlined } from '@ant-design/icons';
-import { getArticleUrl, getImportDetailsUrl, getImportSourceBaseUrl } from '../../utils/urls.js';
+import { getImportDetailsUrl, getImportSourceBaseUrl } from '../../utils/urls.js';
 
-export default function ImportBatchCreation({ PageTemplate }) {
+export default function ImportBatchCreation({ initialState, PageTemplate }) {
+  useReloadPersistedWindow();
   const { t } = useTranslation('importBatchCreation');
-
-  const { language } = useLanguage();
-  const { formatDate } = useDateFormat();
   const clientConfig = useService(ClientConfig);
   const importApiClient = useService(ImportApiClient);
-  const languageNameProvider = useService(LanguageNameProvider);
-
-  const sourceMenuItems = clientConfig.importSources;
-  const { query } = useRequest();
-  const importSourceHostName = decodeURIComponent(query.source);
-  const [selectedSource] = useState(sourceMenuItems.find(source => source.hostName === importSourceHostName));
-
   const [selectedDocumentKeys, setSelectedDocumentKeys] = useState([]);
   const [importableDocuments, setImportableDocuments] = useState([]);
   const [isFetchingImportableDocuments, setIsFetchingImportableDocuments] = useState(false);
   const [isCreatingNewImportBatch, setIsCreatingNewImportBatch] = useState(false);
 
-  useReloadPersistedWindow();
+  const importSource = clientConfig.importSources.find(source => source.hostName === initialState.importSourceHostName);
+  const importSourceBaseUrl = getImportSourceBaseUrl(importSource);
 
   const handleImportClick = async () => {
     setIsCreatingNewImportBatch(true);
@@ -44,7 +30,7 @@ export default function ImportBatchCreation({ PageTemplate }) {
       .map(key => importableDocuments.find(doc => doc.key === key));
 
     const batch = {
-      hostName: selectedSource.hostName,
+      hostName: importSource.hostName,
       documentsToImport: selectedDocs
     };
 
@@ -62,12 +48,9 @@ export default function ImportBatchCreation({ PageTemplate }) {
   useEffect(() => {
     const getDocuments = async () => {
       setIsFetchingImportableDocuments(true);
-
-      setImportableDocuments([]);
-      setSelectedDocumentKeys([]);
-
       try {
-        const { documents } = await importApiClient.getImports(selectedSource.hostName);
+        const { documents } = await importApiClient.getImports(importSource.hostName);
+        setSelectedDocumentKeys([]);
         setImportableDocuments(documents);
       } catch (error) {
         handleApiError({ error, t });
@@ -76,79 +59,31 @@ export default function ImportBatchCreation({ PageTemplate }) {
     };
 
     getDocuments();
-  }, [importApiClient, selectedSource, t]);
-
-  const renderImportType = doc => {
-    let icon = null;
-    if (doc.importType === DOCUMENT_IMPORT_TYPE.add) {
-      icon = <CloudDownloadOutlined />;
-    }
-    if (doc.importType === DOCUMENT_IMPORT_TYPE.update) {
-      icon = <CloudSyncOutlined />;
-    }
-    return <Tooltip title={t(doc.importType)} className="ImportBatchCreationPage-importType">{icon}</Tooltip>;
-  };
-
-  const renderTitle = doc => {
-    if (!doc.slug) {
-      return <span>{doc.title}</span>;
-    }
-
-    const baseUrl = getImportSourceBaseUrl(selectedSource);
-
-    const url = `${baseUrl}${getArticleUrl(doc.slug)}`;
-    return <a href={url} target="_blank" rel="noopener noreferrer" >{doc.title}</a>;
-  };
-
-  const renderLanguage = doc => {
-    const languagesData = languageNameProvider.getData(language);
-    const documentLanguageData = languagesData[doc.language];
-    return <CountryFlagAndName code={documentLanguageData.flag} name={documentLanguageData.name} flagOnly />;
-  };
-
-  const renderUpdateDate = doc => {
-    return <span>{formatDate(doc.updatedOn)}</span>;
-  };
-
-  const columns = [
-    { title: t('importType'), key: 'importType', width: '150px', sorter: by(x => x.importType), render: renderImportType },
-    { title: t('title'), key: 'title', sorter: by(x => x.title), render: renderTitle },
-    { title: t('language'), key: 'language', width: '150px', sorter: by(x => x.language), render: renderLanguage },
-    { title: t('updateDate'), key: 'updateDate', width: '200px', sorter: by(x => x.updatedOn), render: renderUpdateDate }
-  ];
-
-  const tableRowSelection = {
-    onChange: selectedRowKeys => {
-      setSelectedDocumentKeys(selectedRowKeys);
-    }
-  };
+  }, [importApiClient, importSource, t]);
 
   const alerts = useGlobalAlerts();
 
   return (
     <PageTemplate alerts={alerts}>
       <div className="ImportBatchCreationPage">
+        <div><a href="/import-batches">{t('backToImports')}</a></div>
         <h1>{t('pageNames:importBatchCreation')}</h1>
-
-        <h2> {t('source')}: {selectedSource?.name} </h2>
-        <br /> <br />
-
-        <Table
-          bordered
-          size="small"
-          rowKey="key"
-          rowSelection={{
-            type: 'checkbox',
-            ...tableRowSelection
-          }}
-          columns={columns}
-          pagination={false}
-          dataSource={importableDocuments}
+        <h2> {t('source')}: {importSource?.name} </h2>
+        <br />
+        <br />
+        <DocumentImportTable
+          importableDocuments={importableDocuments}
+          importSourceBaseUrl={importSourceBaseUrl}
           loading={isFetchingImportableDocuments}
-          no-data={importableDocuments.length === 0}
+          onSelectedKeysChange={setSelectedDocumentKeys}
           />
         <br />
-        <Button type="primary" disabled={!selectedDocumentKeys.length} loading={isCreatingNewImportBatch} onClick={handleImportClick}>
+        <Button
+          type="primary"
+          disabled={!selectedDocumentKeys.length}
+          loading={isCreatingNewImportBatch}
+          onClick={handleImportClick}
+          >
           {t('importButton')}
         </Button>
       </div>
@@ -157,5 +92,8 @@ export default function ImportBatchCreation({ PageTemplate }) {
 }
 
 ImportBatchCreation.propTypes = {
-  PageTemplate: PropTypes.func.isRequired
+  PageTemplate: PropTypes.func.isRequired,
+  initialState: PropTypes.shape({
+    importSourceHostName: PropTypes.string.isRequired
+  }).isRequired
 };

--- a/src/components/pages/import-batch-creation.less
+++ b/src/components/pages/import-batch-creation.less
@@ -5,7 +5,3 @@
 .ImportBatchCreationPage-source {
   min-width: 280px;
 }
-
-.ImportBatchCreationPage-importType {
-  font-size: 20px;
-}

--- a/src/components/pages/import-batch-creation.yml
+++ b/src/components/pages/import-batch-creation.yml
@@ -1,27 +1,9 @@
 importButton:
   en: Start import
   de: Import starten
-import:
-  en: Import
-  de: Importieren
-importType:
-  en: Import type
-  de: Import-Typ
-title:
-  en: Title
-  de: Titel
-language:
-  en: Language
-  de: Sprache
-updateDate:
-  en: Update date
-  de: Update-Datum
 source:
-  en: Source 
+  en: Source
   de: Quelle
-add:
-  en: Add
-  de: Hinzufügen
-update:
-  en: Update
-  de: Aktualisieren
+backToImports:
+  en: Back to the overview
+  de: Zurück zur Übersicht

--- a/src/components/pages/import-batch-view.js
+++ b/src/components/pages/import-batch-view.js
@@ -142,6 +142,7 @@ function ImportBatchView({ initialState, PageTemplate }) {
   return (
     <PageTemplate alerts={alerts}>
       <div className="ImportBatchViewPage">
+        <div><a href="/import-batches">{t('backToImports')}</a></div>
         <h1>{t('pageNames:importBatchView')}</h1>
         <Row>
           <Space>
@@ -167,6 +168,7 @@ function ImportBatchView({ initialState, PageTemplate }) {
             <span>{batch.createdBy.username}</span>
           </Space>
         </Row>
+        <br />
         <Collapse>
           <Panel header={t('batchErrors')} extra={renderErrorCount(batch)}>
             <List
@@ -180,6 +182,8 @@ function ImportBatchView({ initialState, PageTemplate }) {
         </Collapse>
         <Table
           className="ImportBatchViewPage-tasksTable"
+          size="small"
+          bordered
           key={batch._id}
           rowKey="_id"
           dataSource={batch.tasks}

--- a/src/components/pages/import-batch-view.yml
+++ b/src/components/pages/import-batch-view.yml
@@ -64,3 +64,6 @@ attemptsHeader:
 batchErrors:
   en: Batch errors
   de: Chargenfehler
+backToImports:
+  en: Back to the overview
+  de: Zurück zur Übersicht

--- a/src/components/pages/import-batches.js
+++ b/src/components/pages/import-batches.js
@@ -89,8 +89,17 @@ function ImportBatches({ initialState, PageTemplate }) {
       <div className="ImportBatchesPage">
         <h1>{t('pageNames:importBatches')}</h1>
         {sources.map(source => (
-          <Collapse key={source.importSourceName} className="ImportBatchesPage-sourceCollapse" defaultActiveKey={source.batches.length ? '1' : null}>
-            <Panel header={header(source)} className="ImportBatchesPage-batchTablePanel" extra={getExtra(source)} key="1">
+          <Collapse
+            key={`collapse-${source.importSourceName}`}
+            className="ImportBatchesPage-sourceCollapse"
+            defaultActiveKey={source.batches.length ? `panel-${source.importSourceName}` : null}
+            >
+            <Panel
+              header={header(source)}
+              className="ImportBatchesPage-batchTablePanel"
+              extra={getExtra(source)}
+              key={`panel-${source.importSourceName}`}
+              >
               <Table
                 size="small"
                 rowKey="_id"

--- a/src/components/pages/import-batches.js
+++ b/src/components/pages/import-batches.js
@@ -82,27 +82,25 @@ function ImportBatches({ initialState, PageTemplate }) {
     );
   };
 
-  const defaultActiveKey = sources.filter(source => source.batches.length)
-    .map(source => source.importSourceName);
-
   const alerts = useGlobalAlerts();
 
   return (
     <PageTemplate alerts={alerts}>
       <div className="ImportBatchesPage">
         <h1>{t('pageNames:importBatches')}</h1>
-        <Collapse defaultActiveKey={defaultActiveKey}>
-          {sources.map(source => (
-            <Panel header={header(source)} className="ImportBatchesPage-batchTablePanel" key={source.importSourceName} extra={getExtra(source)} >
+        {sources.map(source => (
+          <Collapse key={source.importSourceName} className="ImportBatchesPage-sourceCollapse" defaultActiveKey={source.batches.length ? '1' : null}>
+            <Panel header={header(source)} className="ImportBatchesPage-batchTablePanel" extra={getExtra(source)} key="1">
               <Table
-                key={source.importSourceName}
+                size="small"
                 rowKey="_id"
                 dataSource={source.batches}
                 columns={columns}
                 pagination={false}
                 />
-            </Panel>))}
-        </Collapse>
+            </Panel>
+          </Collapse>
+        ))}
       </div>
     </PageTemplate>);
 }

--- a/src/components/pages/import-batches.less
+++ b/src/components/pages/import-batches.less
@@ -2,10 +2,16 @@
   .m-content;
 }
 
-.ImportBatchesPage-header { 
+.ImportBatchesPage-header {
   margin-right: 20px
 }
 
-.ImportBatchesPage-batchTablePanel .ant-collapse-content-box {
-  padding: 0;
+.ImportBatchesPage-sourceCollapse {
+  margin-bottom: 40px;
+}
+
+.ImportBatchesPage-batchTablePanel {
+  .ant-collapse-content-box {
+    padding: 0;
+  }
 }

--- a/src/components/pages/import-batches.yml
+++ b/src/components/pages/import-batches.yml
@@ -12,7 +12,7 @@ batchStatusPending:
   de: Ausstehend
 batchStatusDone:
   en: Done
-  de: Vertig
+  de: Abgeschlossen
 batchStatusProcessing:
   en: '{progress, number, percent} completed'
   de: '{progress, number, percent} abgeschlossen'

--- a/src/domain/schemas/import-schemas.js
+++ b/src/domain/schemas/import-schemas.js
@@ -17,6 +17,14 @@ export const getImportsQuerySchema = joi.object({
   hostName: joi.string().required()
 });
 
+export const createImportBatchQuerySchema = joi.object({
+  source: joi.string().required()
+});
+
+export const importBatchViewParamsSchema = joi.object({
+  batchId: idOrKeySchema.required()
+});
+
 export const postImportBatchBodySchema = joi.object({
   hostName: joi.string().required(),
   documentsToImport: joi.array().required().items(importedDocumentSchema)

--- a/src/domain/validation-middleware.js
+++ b/src/domain/validation-middleware.js
@@ -8,6 +8,10 @@ const baseValidator = validator.createValidator({
   joi
 });
 
+export function validateParams(schema) {
+  return baseValidator.params(schema, { joi: defaultValidationOptions });
+}
+
 export function validateQuery(schema) {
   return baseValidator.query(schema, { joi: defaultValidationOptions });
 }

--- a/src/resources/page-names.yml
+++ b/src/resources/page-names.yml
@@ -11,11 +11,11 @@ settings:
   en: Settings
   de: Einstellungen
 importBatchCreation:
-  en: Import
-  de: Import
+  en: Create import
+  de: Import erstellen
 importBatches:
-  en: Imports overview
-  de: Import-Übersicht
+  en: Imports
+  de: Importe
 importBatchView:
   en: Import details
   de: Import-Details

--- a/src/resources/resources.json
+++ b/src/resources/resources.json
@@ -84,6 +84,26 @@
     }
   },
   {
+    "namespace": "documentImportTable",
+    "language": "en",
+    "resources": {
+      "importType": "Import type",
+      "title": "Title",
+      "language": "Language",
+      "updatedOn": "Update date"
+    }
+  },
+  {
+    "namespace": "documentImportTable",
+    "language": "de",
+    "resources": {
+      "importType": "Import-Typ",
+      "title": "Titel",
+      "language": "Sprache",
+      "updatedOn": "Update-Datum"
+    }
+  },
+  {
     "namespace": "documentMetadataEditor",
     "language": "en",
     "resources": {
@@ -364,14 +384,8 @@
     "language": "en",
     "resources": {
       "importButton": "Start import",
-      "import": "Import",
-      "importType": "Import type",
-      "title": "Title",
-      "language": "Language",
-      "updateDate": "Update date",
       "source": "Source",
-      "add": "Add",
-      "update": "Update"
+      "backToImports": "Back to the overview"
     }
   },
   {
@@ -379,14 +393,8 @@
     "language": "de",
     "resources": {
       "importButton": "Import starten",
-      "import": "Importieren",
-      "importType": "Import-Typ",
-      "title": "Titel",
-      "language": "Sprache",
-      "updateDate": "Update-Datum",
       "source": "Quelle",
-      "add": "Hinzufügen",
-      "update": "Aktualisieren"
+      "backToImports": "Zurück zur Übersicht"
     }
   },
   {
@@ -414,7 +422,8 @@
       "errors": "Errors",
       "errorsCount": "Errors count",
       "attemptsHeader": "Attempt details",
-      "batchErrors": "Batch errors"
+      "batchErrors": "Batch errors",
+      "backToImports": "Back to the overview"
     }
   },
   {
@@ -442,7 +451,8 @@
       "errors": "Fehler",
       "errorsCount": "Fehleranzahl",
       "attemptsHeader": "Versuchsdetails",
-      "batchErrors": "Chargenfehler"
+      "batchErrors": "Chargenfehler",
+      "backToImports": "Zurück zur Übersicht"
     }
   },
   {
@@ -472,7 +482,7 @@
       "batchType": "Chargentyp",
       "batchStatus": "Chargenstatus",
       "batchStatusPending": "Ausstehend",
-      "batchStatusDone": "Vertig",
+      "batchStatusDone": "Abgeschlossen",
       "batchStatusProcessing": "{progress, number, percent} abgeschlossen",
       "viewBatch": "Chargen ansehen",
       "batchTypeImportDocument": "Dokumentenimport",
@@ -1321,8 +1331,8 @@
       "users": "Users",
       "account": "My account",
       "settings": "Settings",
-      "importBatchCreation": "Import",
-      "importBatches": "Imports overview",
+      "importBatchCreation": "Create import",
+      "importBatches": "Imports",
       "importBatchView": "Import details",
       "docs": "Documents"
     }
@@ -1335,8 +1345,8 @@
       "users": "Benutzer",
       "account": "Mein Konto",
       "settings": "Einstellungen",
-      "importBatchCreation": "Import",
-      "importBatches": "Import-Übersicht",
+      "importBatchCreation": "Import erstellen",
+      "importBatches": "Importe",
       "importBatchView": "Import-Details",
       "docs": "Dokumente"
     }

--- a/src/styles/main.less
+++ b/src/styles/main.less
@@ -52,6 +52,7 @@
 @import '../components/deleted-section.less';
 @import '../components/credits-footer.less';
 @import '../components/not-supported-section.less';
+@import '../components/document-import-table.less';
 
 // Pure CSS components
 @import '../styles/panel.less';


### PR DESCRIPTION
Unfortunately it's not possible to prevent antd table from a full re-render on each checkbox click (there are a lot of issues on their GH repo, but they're not fixing it). I managed to cut down the lag maybe by 50% but it's still a very bad experience. The only remedies would be either paging or virtualizing the table.

Closes https://educandu.atlassian.net/browse/EDU-149