### PR TITLE
EDU-186 Extract common dev tasks into reusable modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,24 +99,28 @@ to the global-variables.less in educandu and consult the list there.
 
 ~~~
 $ yarn
-$ gulp
+$ gulp                 # run the test application
+$ gulp --instances 3   # run 3 instances behind a load balancer
 ~~~
 
 This will build and start up the TestApp (in watch mode), which is set up to use educandu.
 
 By default the application requires that the following ports are available to be taken:
-  * 3000: the application itself
-  * 8000: maildev server, can be used for debugging emails that would be sent to the users (head to http://localhost:8000 when the application is running)
-  * 8025: smpt server port
+  * 3000: the application itself (or the load balancer)
+  * 400x: the individual application instances, in case of load balancing
+  * 8000: maildev UI, can be used for debugging emails that would be sent to the users (head to http://localhost:8000 when the application is running)
+  * 8025: maildev smpt server port
   * 9000: minio docker image (local CDN used for testing)
   * 21017: mongodb docker image port
 
 The ports can be changed in the gulp file and must be changed in the gulpfile.js and need to be reflected in the test-app/index.js.
 
 The gulpfile has a number of useful tasks which can be run with "gulp taskName", here are some more widely used:
- * test: runs all tests
+ * test: runs all tests (with coverage)
+ * testWatch: runs tests in watch mode
  * testChanged: runs tests that were affected by the current modifications
  * lint: runs lint
+ * up: starts all the containers (if not already running)
  * down: stops all the containers and deletes them
 
 

--- a/dev/cli.js
+++ b/dev/cli.js
@@ -1,0 +1,3 @@
+import yargs from 'yargs';
+
+export const cliArgs = yargs(process.argv.slice(2)).argv;

--- a/dev/docker-container.js
+++ b/dev/docker-container.js
@@ -1,0 +1,61 @@
+import { Docker } from 'docker-cli-js';
+import { delay, isMac, noop } from './helpers.js';
+
+const docker = new Docker({ echo: false });
+
+export const DEFAULT_STARTUP_GRACE_PERIOD = isMac() ? 2500 : 1000;
+
+export class DockerContainer {
+  constructor({ name, image, portMappings = [], env = {}, onFirstRun = noop, startupGracePeriod = DEFAULT_STARTUP_GRACE_PERIOD }) {
+    this.name = name;
+    this.image = image;
+    this.portMappings = portMappings;
+    this.env = env;
+    this.onFirstRun = onFirstRun;
+    this.startupGracePeriod = startupGracePeriod;
+  }
+
+  async ensureIsRunning() {
+    const container = await this._getContainer();
+    if (!container) {
+      await this.run();
+    } else if (!container.status.startsWith('Up')) {
+      await this.restart();
+    }
+  }
+
+  async ensureIsRemoved() {
+    if (await this._getContainer()) {
+      await this.remove();
+    }
+  }
+
+  async run() {
+    let runArgs = `--name ${this.name} -d`;
+    this.portMappings.forEach(portMapping => {
+      runArgs += ` -p ${portMapping}`;
+    });
+    Object.entries(this.env).forEach(([key, value]) => {
+      runArgs += ` -e ${key}="${value}"`;
+    });
+    runArgs += ` ${this.image}`;
+    await docker.command(`run ${runArgs}`);
+    await delay(this.startupGracePeriod);
+    await this.onFirstRun();
+  }
+
+  async restart() {
+    await docker.command(`restart ${this.name}`);
+    await delay(this.startupGracePeriod);
+  }
+
+  async remove() {
+    await docker.command(`rm -f ${this.name}`);
+    await delay(1000);
+  }
+
+  async _getContainer() {
+    const data = await docker.command('ps -a');
+    return data.containerList.find(c => c.names === this.name);
+  }
+}

--- a/dev/helpers.js
+++ b/dev/helpers.js
@@ -1,0 +1,21 @@
+import os from 'os';
+import globModule from 'glob';
+import { promisify } from 'util';
+
+export function delay(ms) {
+  return new Promise(resolve => {
+    setTimeout(resolve, ms);
+  });
+}
+
+export const glob = promisify(globModule);
+
+export function isMac() {
+  return os.platform === 'darwin';
+}
+
+export function kebabToCamel(str) {
+  return str.replace(/-[a-z0-9]/g, c => c.toUpperCase()).replace(/-/g, '');
+}
+
+export function noop() {}

--- a/dev/index.js
+++ b/dev/index.js
@@ -1,0 +1,12 @@
+export { jest } from './jest.js';
+export { cliArgs } from './cli.js';
+export { Process } from './process.js';
+export { NodeProcess } from './node-process.js';
+export { LoadBalancer } from './load-balancer.js';
+export { MongoContainer } from './mongo-container.js';
+export { MinioContainer } from './minio-container.js';
+export { DockerContainer } from './docker-container.js';
+export { MaildevContainer } from './maildev-container.js';
+export { ensureMinioBucketExists } from './minio-helper.js';
+export { delay, glob, isMac, kebabToCamel, noop } from './helpers.js';
+export { LoadBalancedNodeProcessGroup } from './load-balanced-node-process-group.js';

--- a/dev/jest.js
+++ b/dev/jest.js
@@ -1,0 +1,28 @@
+import path from 'path';
+import execa from 'execa';
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
+const resolvedJestModule = require.resolve('jest');
+const index = resolvedJestModule.replaceAll('\\', '/').lastIndexOf('/node_modules/jest/');
+const rootDir = resolvedJestModule.substring(0, index);
+const jestBin = path.resolve(rootDir, './node_modules/jest/bin/jest.js');
+
+const nodeFlags = ['--experimental-vm-modules'];
+
+function runJest(...flags) {
+  const jestFlags = flags.map(flag => `--${flag}`);
+  return execa(process.execPath, [...nodeFlags, jestBin, ...jestFlags], { stdio: 'inherit' });
+}
+
+export const jest = {
+  coverage() {
+    return runJest('coverage', 'runInBand');
+  },
+  changed() {
+    return runJest('onlyChanged');
+  },
+  watch() {
+    return runJest('watch');
+  }
+};

--- a/dev/load-balanced-node-process-group.js
+++ b/dev/load-balanced-node-process-group.js
@@ -1,0 +1,92 @@
+import chalk from 'chalk';
+import { DEFAULT_ENV } from './process.js';
+import { NodeProcess } from './node-process.js';
+import { LoadBalancer } from './load-balancer.js';
+import { chunksToLinesAsync, chomp } from '@rauschma/stringio';
+
+const DEFAULT_INSTANCE_COUNT = 3;
+const DEFAULT_GET_INSTANCE_ENV = () => DEFAULT_ENV;
+
+const colors = [
+  chalk.bgBlue,
+  chalk.bgGreen,
+  chalk.bgMagenta,
+  chalk.bgCyan,
+  chalk.bgYellow
+];
+
+export class LoadBalancedNodeProcessGroup {
+  constructor({
+    script,
+    loadBalancerPort,
+    getNodeProcessPort,
+    instanceCount = DEFAULT_INSTANCE_COUNT,
+    getInstanceEnv = DEFAULT_GET_INSTANCE_ENV
+  }) {
+    const downStreamPorts = [];
+    this._processes = [];
+    for (let index = 0; index < instanceCount; index += 1) {
+      downStreamPorts.push(getNodeProcessPort(index));
+      this._processes.push(new NodeProcess({
+        script,
+        env: getInstanceEnv(index),
+        stdio: ['ignore', 'pipe', process.stderr]
+      }));
+    }
+    this._loadBalancer = new LoadBalancer({
+      port: loadBalancerPort,
+      targets: downStreamPorts.map(p => `http://localhost:${p}`),
+      onProxy: ({ index, req }) => {
+        const prefix = `Proxy request to target #${index}:`;
+        const message = `${chalk.white(prefix)} ${chalk.cyanBright(req.method)} ${req.url}`;
+        this._log(message);
+      }
+    });
+  }
+
+  _log(message, index = -1) {
+    const colorize = index !== -1
+      ? colors[index % colors.length]
+      : chalk.black.bgWhite;
+
+    const prefix = index !== -1
+      ? ` #${index} `
+      : ' LB ';
+
+    // eslint-disable-next-line no-console
+    console.log(`${colorize(prefix)} ${message}`);
+  }
+
+  async _echoReadable(readable, index) {
+    for await (const line of chunksToLinesAsync(readable)) {
+      this._log(chomp(line), index);
+    }
+  }
+
+  async start(env = {}) {
+    await Promise.all(this._processes.map(async (proc, index) => {
+      const child = await proc.start(env);
+      this._echoReadable(child.stdout, index);
+    }));
+    await this._loadBalancer.start();
+  }
+
+  async restart(env = {}) {
+    await this._loadBalancer.stop();
+    await Promise.all(this._processes.map(async (proc, index) => {
+      const child = await proc.restart(env);
+      this._echoReadable(child.stdout, index);
+    }));
+    await this._loadBalancer.start();
+  }
+
+  async kill() {
+    await this._loadBalancer.stop();
+    await Promise.all(this._processes.map(proc => proc.kill()));
+  }
+
+  async waitForExit() {
+    await this._loadBalancer.stop();
+    await Promise.all(this._processes.map(proc => proc.waitForExit()));
+  }
+}

--- a/dev/load-balancer.js
+++ b/dev/load-balancer.js
@@ -1,0 +1,44 @@
+import http from 'http';
+import httpProxy from 'http-proxy';
+import { noop } from './helpers.js';
+
+export class LoadBalancer {
+  constructor({ port, targets, onProxy = noop }) {
+    this.port = port;
+    this.targets = targets;
+    this.onProxy = onProxy;
+    this._cursor = targets.length - 1;
+    this._proxy = null;
+    this._server = null;
+  }
+
+  _getNextTarget() {
+    const nextIndex = (this._cursor + 1) % this.targets.length;
+    this._cursor = nextIndex;
+    return { index: nextIndex, target: this.targets[nextIndex] };
+  }
+
+  start() {
+    this._proxy = httpProxy.createProxyServer({});
+    this._proxy.on('proxyRes', (proxyRes, req) => {
+      proxyRes.headers['x-proxy-target'] = req.targetIndex;
+    });
+    return new Promise((resolve, reject) => {
+      this._server = http.createServer((req, res) => {
+        const { index, target } = this._getNextTarget();
+        req.targetIndex = `#${index}`;
+        this.onProxy({ index, target, req });
+        this._proxy.web(req, res, { target });
+      });
+      this._server.listen(this.port, err => err ? reject(err) : resolve());
+    });
+  }
+
+  async stop() {
+    await new Promise((resolve, reject) => {
+      this._server.close(err => err ? reject(err) : resolve());
+    });
+    this._proxy = null;
+    this._server = null;
+  }
+}

--- a/dev/maildev-container.js
+++ b/dev/maildev-container.js
@@ -1,0 +1,26 @@
+import { noop } from './helpers.js';
+import { DEFAULT_STARTUP_GRACE_PERIOD, DockerContainer } from './docker-container.js';
+
+const DEFAULT_MAILDEV_CONTAINER_NAME = 'maildev';
+const DEFAULT_MAILDEV_IMAGE = 'maildev/maildev:1.1.0';
+
+export class MaildevContainer extends DockerContainer {
+  constructor({
+    smtpPort = 8025,
+    frontendPort = 8000,
+    name = DEFAULT_MAILDEV_CONTAINER_NAME,
+    image = DEFAULT_MAILDEV_IMAGE,
+    env = {},
+    onFirstRun = noop,
+    startupGracePeriod = DEFAULT_STARTUP_GRACE_PERIOD
+  }) {
+    super({
+      name,
+      image,
+      startupGracePeriod,
+      portMappings: [`${smtpPort}:25`, `${frontendPort}:80`],
+      env,
+      onFirstRun
+    });
+  }
+}

--- a/dev/minio-container.js
+++ b/dev/minio-container.js
@@ -1,0 +1,49 @@
+import { noop } from './helpers.js';
+import { ensureMinioBucketExists } from './minio-helper.js';
+import { DEFAULT_STARTUP_GRACE_PERIOD, DockerContainer } from './docker-container.js';
+
+const DEFAULT_MINIO_CONTAINER_NAME = 'minio';
+const DEFAULT_MINIO_IMAGE = 'bitnami/minio:2020.12.18';
+
+export class MinioContainer extends DockerContainer {
+  constructor({
+    accessKey,
+    secretKey,
+    endPoint = 'localhost',
+    port = 9000,
+    useSSL = false,
+    region = 'eu-central-1',
+    initialBuckets = [],
+    name = DEFAULT_MINIO_CONTAINER_NAME,
+    image = DEFAULT_MINIO_IMAGE,
+    env = {},
+    onFirstRun = noop,
+    startupGracePeriod = DEFAULT_STARTUP_GRACE_PERIOD
+  }) {
+    super({
+      name,
+      image,
+      startupGracePeriod,
+      portMappings: [`${port}:9000`],
+      env: {
+        MINIO_ACCESS_KEY: accessKey,
+        MINIO_SECRET_KEY: secretKey,
+        MINIO_DOMAIN: endPoint,
+        MINIO_BROWSER: 'on',
+        ...env
+      },
+      onFirstRun: () => Promise.all([
+        ...initialBuckets.map(bucketName => ensureMinioBucketExists({
+          bucketName,
+          endPoint,
+          port,
+          useSSL,
+          region,
+          accessKey,
+          secretKey
+        })),
+        onFirstRun
+      ])
+    });
+  }
+}

--- a/dev/minio-helper.js
+++ b/dev/minio-helper.js
@@ -1,0 +1,33 @@
+import { Client } from 'minio';
+
+export async function ensureMinioBucketExists({
+  bucketName,
+  endPoint,
+  port,
+  useSSL,
+  region,
+  accessKey,
+  secretKey
+}) {
+  const bucketPolicy = {
+    Version: '2012-10-17',
+    Statement: [
+      {
+        Sid: 'PublicReadGetObject',
+        Effect: 'Allow',
+        Principal: '*',
+        Action: 's3:GetObject',
+        Resource: `arn:aws:s3:::${bucketName}/*`
+      }
+    ]
+  };
+
+  const minioClient = new Client({ endPoint, port, useSSL, region, accessKey, secretKey });
+
+  const buckets = await minioClient.listBuckets();
+
+  if (!buckets.find(x => x.name === bucketName)) {
+    await minioClient.makeBucket(bucketName, region);
+    await minioClient.setBucketPolicy(bucketName, JSON.stringify(bucketPolicy));
+  }
+}

--- a/dev/mongo-container.js
+++ b/dev/mongo-container.js
@@ -1,0 +1,44 @@
+import { noop } from './helpers.js';
+import { DEFAULT_STARTUP_GRACE_PERIOD, DockerContainer } from './docker-container.js';
+
+const DEFAULT_MONGO_CONTAINER_NAME = 'mongo';
+const DEFAULT_MONGO_IMAGE = 'bitnami/mongodb:4.2.17-debian-10-r23';
+
+export class MongoContainer extends DockerContainer {
+  constructor({
+    rootUser,
+    rootPassword,
+    replicaSetName,
+    replicaSetMode = 'primary',
+    advertisedHostname = 'localhost',
+    port = 27017,
+    name = DEFAULT_MONGO_CONTAINER_NAME,
+    image = DEFAULT_MONGO_IMAGE,
+    env = {},
+    onFirstRun = noop,
+    startupGracePeriod = DEFAULT_STARTUP_GRACE_PERIOD
+  }) {
+    const replicaSetEnvParams = replicaSetName
+      ? {
+        MONGODB_REPLICA_SET_KEY: replicaSetName,
+        MONGODB_REPLICA_SET_NAME: replicaSetName,
+        MONGODB_REPLICA_SET_MODE: replicaSetMode
+      }
+      : {};
+
+    super({
+      name,
+      image,
+      startupGracePeriod,
+      portMappings: [`${port}:27017`],
+      env: {
+        MONGODB_ROOT_USER: rootUser,
+        MONGODB_ROOT_PASSWORD: rootPassword,
+        MONGODB_ADVERTISED_HOSTNAME: advertisedHostname,
+        ...replicaSetEnvParams,
+        ...env
+      },
+      onFirstRun
+    });
+  }
+}

--- a/dev/node-process.js
+++ b/dev/node-process.js
@@ -1,0 +1,25 @@
+import { Process, DEFAULT_ENV, DEFAULT_STDIO, DEFAULT_STARTUP_GRACE_PERIOD } from './process.js';
+
+const NODE_FLAGS = [
+  '--experimental-json-modules',
+  '--experimental-loader',
+  '@educandu/node-jsx-loader',
+  '--enable-source-maps'
+];
+
+export class NodeProcess extends Process {
+  constructor({
+    script,
+    env = DEFAULT_ENV,
+    stdio = DEFAULT_STDIO,
+    startupGracePeriod = DEFAULT_STARTUP_GRACE_PERIOD
+  }) {
+    super({
+      command: process.execPath,
+      args: [...NODE_FLAGS, script],
+      env,
+      stdio,
+      startupGracePeriod
+    });
+  }
+}

--- a/dev/process.js
+++ b/dev/process.js
@@ -1,0 +1,62 @@
+import { delay } from './helpers.js';
+import { spawn } from 'child_process';
+
+export const DEFAULT_ENV = { ...process.env };
+export const DEFAULT_STDIO = 'inherit';
+export const DEFAULT_STARTUP_GRACE_PERIOD = 250;
+
+export class Process {
+  constructor({
+    command, args = [],
+    env = DEFAULT_ENV,
+    stdio = DEFAULT_STDIO,
+    startupGracePeriod = DEFAULT_STARTUP_GRACE_PERIOD
+  }) {
+    this.command = command;
+    this.args = args;
+    this.env = env;
+    this.stdio = stdio;
+    this.startupGracePeriod = startupGracePeriod;
+    this._process = null;
+  }
+
+  async start(env = {}) {
+    if (!this._process) {
+      const options = { env: { ...this.env, ...env }, stdio: this.stdio };
+      this._process = spawn(this.command, this.args, options);
+      this._process.once('exit', () => {
+        this._process = null;
+      });
+    }
+
+    await delay(this.startupGracePeriod);
+    return this._process;
+  }
+
+  async restart(env = {}) {
+    await Promise.all([this.waitForExit(), this.kill()]);
+    return this.start(env);
+  }
+
+  async kill() {
+    if (this._process) {
+      this._process.kill();
+      await delay(100);
+    } else {
+      await delay(0);
+    }
+  }
+
+  waitForExit() {
+    return new Promise(resolve => {
+      if (this._process) {
+        this._process.once('exit', async () => {
+          await delay(100);
+          resolve();
+        });
+      } else {
+        delay(0).then(resolve);
+      }
+    });
+  }
+}

--- a/package.json
+++ b/package.json
@@ -109,7 +109,9 @@
   },
   "devDependencies": {
     "@jest/globals": "^27.3.1",
+    "@rauschma/stringio": "^1.4.0",
     "axios-retry": "^3.2.4",
+    "chalk": "^5.0.0",
     "commits-between": "^0.2.0",
     "docker-cli-js": "^2.8.0",
     "envalid": "^7.2.2",
@@ -127,6 +129,7 @@
     "gulp-less": "^5.0.0",
     "gulp-plumber": "^1.2.1",
     "gulp-sourcemaps": "^3.0.0",
+    "http-proxy": "^1.18.1",
     "inquirer": "^8.2.0",
     "jest": "^27.2.5",
     "less-plugin-autoprefix": "^2.0.0",

--- a/test-app/index.js
+++ b/test-app/index.js
@@ -4,7 +4,7 @@ import bundleConfig from './bundles/bundle-config.js';
 import ArticleController from './article-controller.js';
 
 educandu({
-  port: 3000,
+  port: process.env.TEST_APP_PORT || 3000,
   mongoConnectionString: 'mongodb://root:rootpw@localhost:27017/dev-educandu-db?replicaSet=educandurs&authSource=admin',
   skipMongoMigrations: process.env.TEST_APP_SKIP_MONGO_MIGRATIONS === true.toString(),
   includeManualMigrations: true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -725,6 +725,13 @@
     "@nodelib/fs.scandir" "2.1.3"
     fastq "^1.6.0"
 
+"@rauschma/stringio@^1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@rauschma/stringio/-/stringio-1.4.0.tgz#0b667bea726652a10a48dfc1dadc89e0ec51e269"
+  integrity sha512-3uor2f/MXZkmX5RJf8r+OC3WvZVzpSme0yyL0rQDPEnatE02qRcqwEwnsgpgriEck0S/n4vWtUd6tTtrJwk45Q==
+  dependencies:
+    "@types/node" "^10.0.3"
+
 "@rushstack/ts-command-line@^4.7.7":
   version "4.10.2"
   resolved "https://registry.yarnpkg.com/@rushstack/ts-command-line/-/ts-command-line-4.10.2.tgz#019d43d8428e243031c66aeac1f088687f6730f3"
@@ -891,6 +898,11 @@
   version "14.14.14"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.14.tgz#f7fd5f3cc8521301119f63910f0fb965c7d761ae"
   integrity sha512-UHnOPWVWV1z+VV8k6L1HhG7UbGBgIdghqF3l9Ny9ApPghbjICXkUJSd/b9gOgQfjM1r+37cipdw/HJ3F6ICEnQ==
+
+"@types/node@^10.0.3":
+  version "10.17.60"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.17.60.tgz#35f3d6213daed95da7f0f73e75bcc6980e90597b"
+  integrity sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.1"
@@ -2021,6 +2033,11 @@ chalk@^4.1.1:
   dependencies:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
+
+chalk@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-5.0.0.tgz#bd96c6bb8e02b96e08c0c3ee2a9d90e050c7b832"
+  integrity sha512-/duVOqst+luxCQRKEo4bNxinsOQtMP80ZYm7mMqzuh5PociNL0PvmHFvREJ9ueYL2TxlHjBcmLCdmocx9Vg+IQ==
 
 char-regex@^1.0.2:
   version "1.0.2"
@@ -3723,6 +3740,11 @@ event-emitter@^0.3.5:
     d "1"
     es5-ext "~0.10.14"
 
+eventemitter3@^4.0.0:
+  version "4.0.7"
+  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.7.tgz#2de9b68f6528d5644ef5c59526a1b4a07306169f"
+  integrity sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==
+
 events@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/events/-/events-1.1.1.tgz#9ebdb7635ad099c70dcc4c2a1f5004288e8bd924"
@@ -4153,6 +4175,11 @@ flush-write-stream@^1.0.2:
   dependencies:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
+
+follow-redirects@^1.0.0:
+  version "1.14.6"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.6.tgz#8cfb281bbc035b3c067d6cd975b0f6ade6e855cd"
+  integrity sha512-fhUl5EwSJbbl8AR+uYL2KQDxLkdSjZGR36xy46AO7cOMTrCMON6Sa28FmAnC2tRTDbd/Uuzz3aJBv7EBN7JH8A==
 
 follow-redirects@^1.14.4:
   version "1.14.5"
@@ -4846,6 +4873,15 @@ http-proxy-agent@^4.0.1:
     "@tootallnate/once" "1"
     agent-base "6"
     debug "4"
+
+http-proxy@^1.18.1:
+  version "1.18.1"
+  resolved "https://registry.yarnpkg.com/http-proxy/-/http-proxy-1.18.1.tgz#401541f0534884bbf95260334e72f88ee3976549"
+  integrity sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==
+  dependencies:
+    eventemitter3 "^4.0.0"
+    follow-redirects "^1.0.0"
+    requires-port "^1.0.0"
 
 https-proxy-agent@^5.0.0:
   version "5.0.0"
@@ -8509,6 +8545,11 @@ require-main-filename@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-2.0.0.tgz#d0b329ecc7cc0f61649f62215be69af54aa8989b"
   integrity sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==
+
+requires-port@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
+  integrity sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=
 
 resize-observer-polyfill@^1.5.0, resize-observer-polyfill@^1.5.1:
   version "1.5.1"


### PR DESCRIPTION
This PR does a little bit more than in the ticket (sorry, again). The idea is to extract the tasks that are the same in elmu, oma and educandu (and other packages), which is probably 95% reusable (and our gulpfiles a little bit lighter). For now I extracted some stuff to a folder called `dev`, we can continue to do this and then create an npm package out of this directory.

Closes https://educandu.atlassian.net/browse/EDU-186