### PR TITLE
EDU-218 Streamline tabs styling

### DIFF
--- a/src/components/pages/my-space.js
+++ b/src/components/pages/my-space.js
@@ -14,6 +14,7 @@ import { getGlobalAlerts } from '../../ui/global-alerts.js';
 import { FEATURE_TOGGLES } from '../../domain/constants.js';
 
 const { TabPane } = Tabs;
+
 function MySpace({ initialState, PageTemplate }) {
   const user = useUser();
   const pageName = usePageName();
@@ -54,15 +55,15 @@ function MySpace({ initialState, PageTemplate }) {
       <div className="MySpacePage">
 
         <h1>{t('pageNames:mySpace')}</h1>
-        <Tabs className="MySpacePage-tabs" defaultActiveKey="1" type="card" size="large">
-          <TabPane className="MySpacePage-tab" tab={t('profileTabTitle')} key="1">
+        <Tabs className="Tabs" defaultActiveKey="1" type="line" size="large">
+          <TabPane className="Tabs-tabPane" tab={t('profileTabTitle')} key="1">
             <ProfileTab formItemLayout={formItemLayout} tailFormItemLayout={tailFormItemLayout} />
           </TabPane>
-          <TabPane className="MySpacePage-tab" tab={t('accountTabTitle')} key="2">
+          <TabPane className="Tabs-tabPane" tab={t('accountTabTitle')} key="2">
             <AccountTab formItemLayout={formItemLayout} tailFormItemLayout={tailFormItemLayout} />
           </TabPane>
           { isRoomsTabEnabled && (
-            <TabPane className="MySpacePage-tab" tab={t('roomsTabTitle')} key="3">
+            <TabPane className="Tabs-tabPane" tab={t('roomsTabTitle')} key="3">
               <RoomsTab rooms={rooms} />
             </TabPane>)}
         </Tabs>

--- a/src/components/pages/my-space.less
+++ b/src/components/pages/my-space.less
@@ -1,7 +1,3 @@
 .MySpacePage {
   .m-content;
 }
-
-.MySpacePage-tab {
-  padding-top: 50px;
-}

--- a/src/components/pages/users.js
+++ b/src/components/pages/users.js
@@ -3,7 +3,7 @@ import firstBy from 'thenby';
 import autoBind from 'auto-bind';
 import PropTypes from 'prop-types';
 import Logger from '../../common/logger.js';
-import { Table, Popover, Menu } from 'antd';
+import { Table, Popover, Tabs } from 'antd';
 import { withUser } from '../user-context.js';
 import { withTranslation } from 'react-i18next';
 import { ROLE } from '../../domain/constants.js';
@@ -19,7 +19,7 @@ import { userShape, translationProps, userProps, pageNameProps } from '../../ui/
 
 const logger = new Logger(import.meta.url);
 
-const MenuItem = Menu.Item;
+const { TabPane } = Tabs;
 
 const availableRoles = Object.values(ROLE);
 
@@ -57,7 +57,6 @@ class Users extends React.Component {
 
     this.state = {
       ...splitInternalAndExternalUsers(props.initialState),
-      currentTab: TABS.internalUsers,
       isSaving: false
     };
 
@@ -175,10 +174,6 @@ class Users extends React.Component {
     return <UserLockedOutStateEditor user={user} onLockedOutStateChange={this.handleLockedOutStateChange} />;
   }
 
-  handleTabClick(evt) {
-    this.setState({ currentTab: evt.key });
-  }
-
   async handleRoleChange(user, newRoles) {
     const { userApiClient, t } = this.props;
     const oldRoles = user.roles;
@@ -227,7 +222,7 @@ class Users extends React.Component {
 
   render() {
     const { t, PageTemplate, pageName, user } = this.props;
-    const { internalUsers, externalUsers, isSaving, currentTab } = this.state;
+    const { internalUsers, externalUsers, isSaving } = this.state;
 
     const alerts = getGlobalAlerts(pageName, user);
 
@@ -235,31 +230,27 @@ class Users extends React.Component {
       <PageTemplate alerts={alerts}>
         <div className="UsersPage">
           <h1>{t('pageNames:users')}</h1>
-          <Menu onClick={this.handleTabClick} selectedKeys={[currentTab]} mode="horizontal" disabled={isSaving}>
-            <MenuItem key={TABS.internalUsers}>{t('internalUsers')}</MenuItem>
-            <MenuItem key={TABS.externalUsers}>{t('externalUsers')}</MenuItem>
-          </Menu>
-          <br />
-          <br />
-          {currentTab === TABS.internalUsers && (
-            <Table
-              dataSource={internalUsers}
-              columns={this.internalUserTableColumns}
-              rowKey="_id"
-              size="middle"
-              loading={isSaving}
-              bordered
-              />
-          )}
-          {currentTab === TABS.externalUsers && (
-            <Table
-              dataSource={externalUsers}
-              columns={this.externalUserTableColumns}
-              rowKey="_id"
-              size="middle"
-              bordered
-              />
-          )}
+          <Tabs className="Tabs" defaultActiveKey={TABS.internalUsers} type="line" size="large" disabled={isSaving}>
+            <TabPane className="Tabs-tabPane" tab={t('internalUsers')} key={TABS.internalUsers}>
+              <Table
+                dataSource={internalUsers}
+                columns={this.internalUserTableColumns}
+                rowKey="_id"
+                size="middle"
+                loading={isSaving}
+                bordered
+                />
+            </TabPane>
+            <TabPane className="Tabs-tabPane" tab={t('externalUsers')} key={TABS.externalUsers}>
+              <Table
+                dataSource={externalUsers}
+                columns={this.externalUserTableColumns}
+                rowKey="_id"
+                size="middle"
+                bordered
+                />
+            </TabPane>
+          </Tabs>
         </div>
       </PageTemplate>
     );

--- a/src/components/rooms-tab.less
+++ b/src/components/rooms-tab.less
@@ -3,7 +3,7 @@
 }
 
 .RoomsTab-section {
-  padding-top: 100px;
+  padding-top: 60px;
 
   &:first-of-type {
     padding-top: 0;

--- a/src/styles/main.less
+++ b/src/styles/main.less
@@ -62,6 +62,7 @@
 @import '../components/rooms-tab.less';
 
 // Pure CSS components
+@import '../styles/tabs.less';
 @import '../styles/panel.less';
 @import '../styles/content.less';
 @import '../styles/section.less';

--- a/src/styles/tabs.less
+++ b/src/styles/tabs.less
@@ -1,0 +1,7 @@
+.Tabs {
+  padding-top: 20px;
+}
+
+.Tabs-tabPane {
+  padding-top: 50px;
+}


### PR DESCRIPTION
Closes https://educandu.atlassian.net/browse/EDU-218

I made `my-space` look like `users`, but made `users` use the same component as `my-space` :)
How's that for compromise?


Looks like this:

<img width="1201" alt="Screen Shot 2021-12-28 at 15 48 12" src="https://user-images.githubusercontent.com/8189923/147579079-04456934-764a-407c-b9cf-51a3dc2e10a6.png">
