### PR TITLE
EDU-226 Toggle tests order in ear-training plugin

### DIFF
--- a/migrations/automatic/educandu-2022-01-03-01-add-ear-training-tests-order.js
+++ b/migrations/automatic/educandu-2022-01-03-01-add-ear-training-tests-order.js
@@ -1,0 +1,76 @@
+/* eslint-disable camelcase, no-await-in-loop, no-console */
+const PLUGIN_TYPE = 'ear-training';
+
+export default class Educandu_2022_01_03_01_add_ear_training_tests_order {
+  constructor(db) {
+    this.db = db;
+  }
+
+  async updateCollection(collection, doUpdate) {
+    const cursor = collection.find({ 'sections.type': PLUGIN_TYPE });
+
+    while (await cursor.hasNext()) {
+      const doc = await cursor.next();
+
+      const isUpdated = await doUpdate(doc);
+
+      if (isUpdated) {
+        await collection.replaceOne({ _id: doc._id }, doc);
+      }
+    }
+  }
+
+  docUp(doc) {
+    let changedSectionsCount = 0;
+
+    doc.sections
+      .filter(section => section.content && section.type === PLUGIN_TYPE)
+      .forEach(section => {
+        if (!section.content.testsOrder) {
+          section.content.testsOrder = 'random';
+          changedSectionsCount += 1;
+        }
+      });
+
+    if (changedSectionsCount) {
+      const docType = doc.revision ? 'document' : 'documentRevision';
+      console.log(`Updating ${changedSectionsCount} section(s) in ${docType} '${doc._id}'`);
+
+      return true;
+    }
+
+    return false;
+  }
+
+  docDown(doc) {
+    let changedSectionsCount = 0;
+
+    doc.sections
+      .filter(section => section.content && section.type === PLUGIN_TYPE)
+      .forEach(section => {
+        if (section.content.testsOrder) {
+          delete section.content.testsOrder;
+          changedSectionsCount += 1;
+        }
+      });
+
+    if (changedSectionsCount) {
+      const docType = doc.revision ? 'document' : 'documentRevision';
+      console.log(`Updating ${changedSectionsCount} section(s) in ${docType} '${doc._id}'`);
+
+      return true;
+    }
+
+    return false;
+  }
+
+  async up() {
+    await this.updateCollection(this.db.collection('documentRevisions'), this.docUp);
+    await this.updateCollection(this.db.collection('documents'), this.docUp);
+  }
+
+  async down() {
+    await this.updateCollection(this.db.collection('documentRevisions'), this.docDown);
+    await this.updateCollection(this.db.collection('documents'), this.docDown);
+  }
+}

--- a/src/plugins/ear-training/constants.js
+++ b/src/plugins/ear-training/constants.js
@@ -3,3 +3,8 @@ export const SOUND_TYPE = {
   external: 'external',
   midi: 'midi'
 };
+
+export const TESTS_ORDER = {
+  given: 'given',
+  random: 'random'
+};

--- a/src/plugins/ear-training/display/ear-training-display.js
+++ b/src/plugins/ear-training/display/ear-training-display.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import autoBind from 'auto-bind';
-import { SOUND_TYPE } from '../constants.js';
+import { SOUND_TYPE, TESTS_ORDER } from '../constants.js';
 import { withTranslation } from 'react-i18next';
 import { shuffleItems } from '../../../utils/array-utils.js';
 import AudioPlayer from '../../../components/audio-player.js';
@@ -38,7 +38,7 @@ class EarTrainingDisplay extends React.Component {
     this.state = {
       title: content.title,
       maxWidth: content.maxWidth,
-      tests: shuffleItems(content.tests),
+      tests: content.testsOrder === TESTS_ORDER.random ? shuffleItems(content.tests) : content.tests,
       currentIndex: 0,
       showResult: false
     };

--- a/src/plugins/ear-training/ear-training.yml
+++ b/src/plugins/ear-training/ear-training.yml
@@ -43,3 +43,12 @@ internalUrl:
 copyrightInfos:
   en: Copyright infos
   de: Copyright Infos
+testsOrder:
+  en: Display order
+  de: Anzeigereihenfolge
+testsOrderGiven:
+  en: as given
+  de: wie angegeben
+testsOrderRandom:
+  en: random
+  de: zufällig

--- a/src/plugins/ear-training/editing/ear-training-editor.js
+++ b/src/plugins/ear-training/editing/ear-training-editor.js
@@ -1,8 +1,8 @@
 import React from 'react';
 import autoBind from 'auto-bind';
-import { SOUND_TYPE } from '../constants.js';
 import { withTranslation } from 'react-i18next';
-import { Form, Input, Table, Button } from 'antd';
+import { Form, Input, Table, Button, Radio } from 'antd';
+import { SOUND_TYPE, TESTS_ORDER } from '../constants.js';
 import EarTrainingSoundEditor from './ear-training-sound-editor.js';
 import { swapItemsAt, removeItemAt } from '../../../utils/array-utils.js';
 import ObjectMaxWidthSlider from '../../../components/object-max-width-slider.js';
@@ -11,6 +11,8 @@ import { ArrowUpOutlined, ArrowDownOutlined, PlusOutlined, DeleteOutlined } from
 
 const { TextArea } = Input;
 const FormItem = Form.Item;
+const RadioGroup = Radio.Group;
+const RadioButton = Radio.Button;
 const ButtonGroup = Button.Group;
 
 const defaultSound = { type: SOUND_TYPE.midi, url: null, text: null };
@@ -158,6 +160,10 @@ class EarTrainingEditor extends React.Component {
     this.changeContent({ tests: newTests });
   }
 
+  handleTestsOrderChanged(event) {
+    this.changeContent({ testsOrder: event.target.value });
+  }
+
   render() {
     const formItemLayout = {
       labelCol: { span: 4 },
@@ -180,6 +186,12 @@ class EarTrainingEditor extends React.Component {
           <Form.Item label={t('maximumWidth')} {...formItemLayout}>
             <ObjectMaxWidthSlider defaultValue={100} value={content.maxWidth} onChange={this.handleMaxWidthChanged} />
           </Form.Item>
+          <FormItem label={t('testsOrder')} {...formItemLayout}>
+            <RadioGroup value={content.testsOrder} onChange={this.handleTestsOrderChanged}>
+              <RadioButton value={TESTS_ORDER.given}>{t('testsOrderGiven')}</RadioButton>
+              <RadioButton value={TESTS_ORDER.random}>{t('testsOrderRandom')}</RadioButton>
+            </RadioGroup>
+          </FormItem>
         </Form>
         <Table
           dataSource={dataSource}

--- a/src/plugins/ear-training/info.js
+++ b/src/plugins/ear-training/info.js
@@ -1,4 +1,4 @@
-import { SOUND_TYPE } from './constants.js';
+import { SOUND_TYPE, TESTS_ORDER } from './constants.js';
 import cloneDeep from '../../utils/clone-deep.js';
 
 export default class EarTraining {
@@ -26,7 +26,8 @@ export default class EarTraining {
             text: null
           }
         }
-      ]
+      ],
+      testsOrder: TESTS_ORDER.given
     };
   }
 

--- a/src/resources/resources.json
+++ b/src/resources/resources.json
@@ -1147,7 +1147,10 @@
       "internalCdn": "Internal CDN",
       "externalUrl": "External URL",
       "internalUrl": "Internal URL",
-      "copyrightInfos": "Copyright infos"
+      "copyrightInfos": "Copyright infos",
+      "testsOrder": "Display order",
+      "testsOrderGiven": "as given",
+      "testsOrderRandom": "random"
     }
   },
   {
@@ -1168,7 +1171,10 @@
       "internalCdn": "Internes CDN",
       "externalUrl": "Externe URL",
       "internalUrl": "Interne URL",
-      "copyrightInfos": "Copyright Infos"
+      "copyrightInfos": "Copyright Infos",
+      "testsOrder": "Anzeige Reihnfolge",
+      "testsOrderGiven": "als gegeben",
+      "testsOrderRandom": "zufällig"
     }
   },
   {

--- a/src/resources/resources.json
+++ b/src/resources/resources.json
@@ -1172,8 +1172,8 @@
       "externalUrl": "Externe URL",
       "internalUrl": "Interne URL",
       "copyrightInfos": "Copyright Infos",
-      "testsOrder": "Anzeige Reihnfolge",
-      "testsOrderGiven": "als gegeben",
+      "testsOrder": "Anzeigereihenfolge",
+      "testsOrderGiven": "wie angegeben",
       "testsOrderRandom": "zufällig"
     }
   },


### PR DESCRIPTION
Closes https://educandu.atlassian.net/browse/EDU-226

The migration script ran locally, over a prod db dump, in `5.36s` over 52 documents.