### PR TITLE
EDU-249 Fix login issue

### DIFF
--- a/src/server/user-controller.js
+++ b/src/server/user-controller.js
@@ -183,7 +183,7 @@ class UserController {
 
   registerMiddleware(router) {
     router.use(session({
-      name: 'SESSION_ID',
+      name: `SESSION_ID_${this.serverConfig.sessionCookieDomain.toUpperCase()}`,
       cookie: {
         httpOnly: true,
         domain: this.serverConfig.sessionCookieDomain


### PR DESCRIPTION
Closes: https://educandu.atlassian.net/browse/EDU-249

The problem:
 We set the Domain on the HTTP only cookie SESSION_ID on prod which causes it to be sent to all subdomains. We need this since we want to send it to cdn.open-music.academy for example for roomId verification. 
 The drawback is that staging.elmu.online is also a subdomain, so after logging into staging as well, we send 2 SESSION_ID cookies with the values for prod and for staging. Since the name is the same the servers finds the first one (the prod one) and says you are not logged in. 
The current solution:
 Have separate names for the session cookies so there is no confusion on the server side although both sessions will be sent.
 We will need to change the cookie name setting on the lambdas if we take this solution as well.

I don't immediately see an alternative, at least not by reading the MDN page on cookies.

