### PR TITLE
EDU-356 Show storage tab on MySpace page

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,6 @@
 export default {
   testEnvironment: 'node',
-  testTimeout: 10000,
+  testTimeout: 15000,
   setupFiles: ['<rootDir>/src/test-setup.js'],
   coveragePathIgnorePatterns: [
     '<rootDir>/[^/]\\.js',

--- a/src/components/pages/my-space.js
+++ b/src/components/pages/my-space.js
@@ -4,20 +4,23 @@ import PropTypes from 'prop-types';
 import RoomsTab from '../rooms-tab.js';
 import ProfileTab from '../profile-tab.js';
 import AccountTab from '../account-tab.js';
+import { useUser } from '../user-context.js';
+import UsedStorage from '../used-storage.js';
 import { useTranslation } from 'react-i18next';
 import { useService } from '../container-context.js';
-import { roomShape } from '../../ui/default-prop-types.js';
 import ClientConfig from '../../bootstrap/client-config.js';
 import { useGlobalAlerts } from '../../ui/global-alerts.js';
+import { roomShape, storagePlanShape } from '../../ui/default-prop-types.js';
 
 const { TabPane } = Tabs;
 
 function MySpace({ initialState, PageTemplate }) {
+  const user = useUser();
   const alerts = useGlobalAlerts();
   const { t } = useTranslation('mySpace');
   const clientConfig = useService(ClientConfig);
 
-  const { rooms } = initialState;
+  const { rooms, storagePlan } = initialState;
 
   const formItemLayout = {
     labelCol: {
@@ -59,6 +62,13 @@ function MySpace({ initialState, PageTemplate }) {
           <TabPane className="Tabs-tabPane" tab={t('accountTabTitle')} key="3">
             <AccountTab formItemLayout={formItemLayout} tailFormItemLayout={tailFormItemLayout} />
           </TabPane>
+          {user.storage && (
+            <TabPane className="Tabs-tabPane" tab={t('common:storage')} key="4">
+              <h5>{`"${storagePlan.name}" ${t('storagePlanLabel')}`}</h5>
+              <span className="MySpacePage-usedStorage">{t('usedStorageLabel')}:</span>
+              <UsedStorage usedBytes={user.storage.usedStorageInBytes} maxBytes={storagePlan.maxSizeInBytes} />
+            </TabPane>
+          )}
         </Tabs>
 
       </div>
@@ -69,7 +79,8 @@ function MySpace({ initialState, PageTemplate }) {
 MySpace.propTypes = {
   PageTemplate: PropTypes.func.isRequired,
   initialState: PropTypes.shape({
-    rooms: PropTypes.arrayOf(roomShape).isRequired
+    rooms: PropTypes.arrayOf(roomShape).isRequired,
+    storagePlan: storagePlanShape
   }).isRequired
 };
 

--- a/src/components/pages/my-space.js
+++ b/src/components/pages/my-space.js
@@ -46,6 +46,8 @@ function MySpace({ initialState, PageTemplate }) {
     }
   };
 
+  const storagePlanName = storagePlan ? `"${storagePlan.name}" ${t('storagePlanLabel')}` : t('noStoragePlanLabel');
+
   return (
     <PageTemplate alerts={alerts} disableProfileWarning>
       <div className="MySpacePage">
@@ -64,10 +66,10 @@ function MySpace({ initialState, PageTemplate }) {
           </TabPane>
           {user.storage && (
             <TabPane className="Tabs-tabPane" tab={t('common:storage')} key="4">
-              <h5>{`"${storagePlan.name}" ${t('storagePlanLabel')}`}</h5>
+              <h5>{storagePlanName}</h5>
               <div className="MySpacePage-usedStorage">
                 <span className="MySpacePage-usedStorageLabel">{t('usedStorageLabel')}:</span>
-                <UsedStorage usedBytes={user.storage.usedStorageInBytes} maxBytes={storagePlan.maxSizeInBytes} />
+                <UsedStorage usedBytes={user.storage.usedStorageInBytes} maxBytes={storagePlan?.maxSizeInBytes} />
               </div>
             </TabPane>
           )}

--- a/src/components/pages/my-space.js
+++ b/src/components/pages/my-space.js
@@ -65,8 +65,10 @@ function MySpace({ initialState, PageTemplate }) {
           {user.storage && (
             <TabPane className="Tabs-tabPane" tab={t('common:storage')} key="4">
               <h5>{`"${storagePlan.name}" ${t('storagePlanLabel')}`}</h5>
-              <span className="MySpacePage-usedStorage">{t('usedStorageLabel')}:</span>
-              <UsedStorage usedBytes={user.storage.usedStorageInBytes} maxBytes={storagePlan.maxSizeInBytes} />
+              <div className="MySpacePage-usedStorage">
+                <span className="MySpacePage-usedStorageLabel">{t('usedStorageLabel')}:</span>
+                <UsedStorage usedBytes={user.storage.usedStorageInBytes} maxBytes={storagePlan.maxSizeInBytes} />
+              </div>
             </TabPane>
           )}
         </Tabs>

--- a/src/components/pages/my-space.less
+++ b/src/components/pages/my-space.less
@@ -1,3 +1,8 @@
 .MySpacePage {
   .m-content;
 }
+
+.MySpacePage-usedStorage {
+  display: block;
+  margin-top: 20px;
+}

--- a/src/components/pages/my-space.less
+++ b/src/components/pages/my-space.less
@@ -3,6 +3,11 @@
 }
 
 .MySpacePage-usedStorage {
-  display: block;
+  display: flex;
+  align-items: baseline;
   margin-top: 20px;
+}
+
+.MySpacePage-usedStorageLabel {
+  margin-right: 15px;
 }

--- a/src/components/pages/my-space.yml
+++ b/src/components/pages/my-space.yml
@@ -10,6 +10,9 @@ roomsTabTitle:
 storagePlanLabel:
   en: storage plan
   de: Speicherplan
+noStoragePlanLabel:
+  en: No storage plan
+  de: Kein Speicherplan
 usedStorageLabel:
   en: Used
   de: Benutzt

--- a/src/components/pages/my-space.yml
+++ b/src/components/pages/my-space.yml
@@ -7,3 +7,9 @@ accountTabTitle:
 roomsTabTitle:
   en: Rooms
   de: Räume
+storagePlanLabel:
+  en: storage plan
+  de: Speicherplan
+usedStorageLabel:
+  en: Used
+  de: Benutzt

--- a/src/components/pages/users.js
+++ b/src/components/pages/users.js
@@ -15,7 +15,7 @@ import UserApiClient from '../../api-clients/user-api-client.js';
 import { useSessionAwareApiClient } from '../../ui/api-helper.js';
 import CountryFlagAndName from '../localization/country-flag-and-name.js';
 import UserLockedOutStateEditor from '../user-locked-out-state-editor.js';
-import { userShape, storagePlanShape } from '../../ui/default-prop-types.js';
+import { userShape, baseStoragePlanShape } from '../../ui/default-prop-types.js';
 
 const logger = new Logger(import.meta.url);
 
@@ -250,7 +250,7 @@ function Users({ initialState, PageTemplate }) {
       key: 'roles',
       render: renderRoleTags
     }, {
-      title: () => t('storage'),
+      title: () => t('common:storage'),
       dataIndex: 'storage',
       key: 'storage',
       render: renderStorage,
@@ -307,7 +307,7 @@ Users.propTypes = {
   PageTemplate: PropTypes.func.isRequired,
   initialState: PropTypes.shape({
     users: PropTypes.arrayOf(userShape).isRequired,
-    storagePlans: PropTypes.arrayOf(storagePlanShape).isRequired
+    storagePlans: PropTypes.arrayOf(baseStoragePlanShape).isRequired
   }).isRequired
 };
 

--- a/src/components/pages/users.yml
+++ b/src/components/pages/users.yml
@@ -43,9 +43,6 @@ internalUsers:
 externalUsers:
   en: External users
   de: Externe Benutzer
-storage:
-  en: Storage
-  de: Speicher
 selectPlan:
   en: Select plan
   de: Plan auswählen

--- a/src/components/used-storage.js
+++ b/src/components/used-storage.js
@@ -1,40 +1,27 @@
 import React from 'react';
 import { Progress } from 'antd';
 import PropTypes from 'prop-types';
-
-function convertBytesToHigherUnit(bytes) {
-  const kilobytes = bytes / 1000;
-  if (kilobytes < 1000) {
-    return `${kilobytes} KB`;
-  }
-  const megabytes = kilobytes / 1000;
-  if (megabytes < 1000) {
-    return `${megabytes} MB`;
-  }
-  const gigabytes = megabytes / 1000;
-  return `${gigabytes} GB`;
-}
+import prettyBytes from 'pretty-bytes';
+import { useLocale } from './locale-context.js';
 
 function UsedStorage({ usedBytes, maxBytes }) {
-  const format = percent => `${percent} %`;
+  const { uiLocale } = useLocale();
+
   const percent = usedBytes * 100 / maxBytes;
+  const displayedPercent = `${Math.round(percent)} %`;
   const status = percent >= 95 ? 'exception' : 'normal';
 
-  const maxSpace = convertBytesToHigherUnit(maxBytes);
-  const usedSpace = convertBytesToHigherUnit(usedBytes);
+  const maxSpace = prettyBytes(maxBytes, { locale: uiLocale });
+  const usedSpace = prettyBytes(usedBytes, { locale: uiLocale });
 
   return (
     <div className="UsedStorage">
-      <Progress
-        className="UserStorage-progress"
-        strokeLinecap="square"
-        percent={percent}
-        status={status}
-        format={format}
-        />
-      <span className="UsedStorage-value">{`${usedSpace} / ${maxSpace}`}</span>
+      <div className="UsedStorage-progress">
+        <Progress strokeLinecap="square" percent={percent} status={status} showInfo={false} />
+        <span className="UserStorage-progressPercentage">{displayedPercent}</span>
+      </div>
+      <span className="UsedStorage-occupiedSpace">{`${usedSpace} / ${maxSpace}`}</span>
     </div>
-
   );
 }
 

--- a/src/components/used-storage.js
+++ b/src/components/used-storage.js
@@ -1,0 +1,46 @@
+import React from 'react';
+import { Progress } from 'antd';
+import PropTypes from 'prop-types';
+
+function convertBytesToHigherUnit(bytes) {
+  const kilobytes = bytes / 1000;
+  if (kilobytes < 1000) {
+    return `${kilobytes} KB`;
+  }
+  const megabytes = kilobytes / 1000;
+  if (megabytes < 1000) {
+    return `${megabytes} MB`;
+  }
+  const gigabytes = megabytes / 1000;
+  return `${gigabytes} GB`;
+}
+
+function UsedStorage({ usedBytes, maxBytes }) {
+  const format = percent => `${percent} %`;
+  const percent = usedBytes * 100 / maxBytes;
+  const status = percent >= 95 ? 'exception' : 'normal';
+
+  const maxSpace = convertBytesToHigherUnit(maxBytes);
+  const usedSpace = convertBytesToHigherUnit(usedBytes);
+
+  return (
+    <div className="UsedStorage">
+      <Progress
+        className="UserStorage-progress"
+        strokeLinecap="square"
+        percent={percent}
+        status={status}
+        format={format}
+        />
+      <span className="UsedStorage-value">{`${usedSpace} / ${maxSpace}`}</span>
+    </div>
+
+  );
+}
+
+UsedStorage.propTypes = {
+  maxBytes: PropTypes.number.isRequired,
+  usedBytes: PropTypes.number.isRequired
+};
+
+export default UsedStorage;

--- a/src/components/used-storage.js
+++ b/src/components/used-storage.js
@@ -7,7 +7,7 @@ import { useLocale } from './locale-context.js';
 function UsedStorage({ usedBytes, maxBytes }) {
   const { uiLocale } = useLocale();
 
-  const percent = usedBytes * 100 / maxBytes;
+  const percent = maxBytes ? usedBytes * 100 / maxBytes : 100;
   const displayedPercent = `${Math.round(percent)} %`;
   const status = percent >= 95 ? 'exception' : 'normal';
 
@@ -26,8 +26,12 @@ function UsedStorage({ usedBytes, maxBytes }) {
 }
 
 UsedStorage.propTypes = {
-  maxBytes: PropTypes.number.isRequired,
+  maxBytes: PropTypes.number,
   usedBytes: PropTypes.number.isRequired
+};
+
+UsedStorage.defaultProps = {
+  maxBytes: 0
 };
 
 export default UsedStorage;

--- a/src/components/used-storage.less
+++ b/src/components/used-storage.less
@@ -1,0 +1,13 @@
+.UsedStorage {
+  margin: 10px 0;
+}
+
+.UserStorage-progress {
+  padding: 0 5px;
+}
+
+.UsedStorage-value {
+  font-size: 10px;
+  display: flex;
+  justify-content: flex-end;
+}

--- a/src/components/used-storage.less
+++ b/src/components/used-storage.less
@@ -1,12 +1,19 @@
 .UsedStorage {
+  width: 100%;
   margin: 10px 0;
 }
 
-.UserStorage-progress {
-  padding: 0 5px;
+.UsedStorage-progress {
+  margin: 10px 0;
+  display: flex;
 }
 
-.UsedStorage-value {
+.UserStorage-progressPercentage {
+  padding-left: 10px;
+  flex-shrink: 0;
+}
+
+.UsedStorage-occupiedSpace {
   font-size: 10px;
   display: flex;
   justify-content: flex-end;

--- a/src/components/used-storage.less
+++ b/src/components/used-storage.less
@@ -4,7 +4,6 @@
 }
 
 .UsedStorage-progress {
-  margin: 10px 0;
   display: flex;
 }
 

--- a/src/resources/common.yml
+++ b/src/resources/common.yml
@@ -178,3 +178,6 @@ alt:
 unknown:
   en: Unknown
   de: Unbekannt
+storage:
+  en: Storage
+  de: Speicher

--- a/src/resources/resources.json
+++ b/src/resources/resources.json
@@ -577,6 +577,7 @@
       "accountTabTitle": "Account",
       "roomsTabTitle": "Rooms",
       "storagePlanLabel": "storage plan",
+      "noStoragePlanLabel": "No storage plan",
       "usedStorageLabel": "Used"
     }
   },
@@ -588,6 +589,7 @@
       "accountTabTitle": "Konto",
       "roomsTabTitle": "Räume",
       "storagePlanLabel": "Speicherplan",
+      "noStoragePlanLabel": "Kein Speicherplan",
       "usedStorageLabel": "Benutzt"
     }
   },

--- a/src/resources/resources.json
+++ b/src/resources/resources.json
@@ -575,7 +575,9 @@
     "resources": {
       "profileTabTitle": "Profile",
       "accountTabTitle": "Account",
-      "roomsTabTitle": "Rooms"
+      "roomsTabTitle": "Rooms",
+      "storagePlanLabel": "storage plan",
+      "usedStorageLabel": "Used"
     }
   },
   {
@@ -584,7 +586,9 @@
     "resources": {
       "profileTabTitle": "Profil",
       "accountTabTitle": "Konto",
-      "roomsTabTitle": "Räume"
+      "roomsTabTitle": "Räume",
+      "storagePlanLabel": "Speicherplan",
+      "usedStorageLabel": "Benutzt"
     }
   },
   {
@@ -776,7 +780,6 @@
       "importSource": "Import source",
       "internalUsers": "Internal users",
       "externalUsers": "External users",
-      "storage": "Storage",
       "selectPlan": "Select plan"
     }
   },
@@ -799,7 +802,6 @@
       "importSource": "Import-Quelle",
       "internalUsers": "Interne Benutzer",
       "externalUsers": "Externe Benutzer",
-      "storage": "Speicher",
       "selectPlan": "Plan auswählen"
     }
   },
@@ -1536,7 +1538,8 @@
       "ctrl": "Ctrl",
       "shift": "Shift",
       "alt": "Alt",
-      "unknown": "Unknown"
+      "unknown": "Unknown",
+      "storage": "Storage"
     }
   },
   {
@@ -1602,7 +1605,8 @@
       "ctrl": "Strg",
       "shift": "Umschalt",
       "alt": "Alt",
-      "unknown": "Unbekannt"
+      "unknown": "Unbekannt",
+      "storage": "Speicher"
     }
   },
   {

--- a/src/server/my-space-controller.js
+++ b/src/server/my-space-controller.js
@@ -21,7 +21,7 @@ class UserController {
     const { user } = req;
 
     let storagePlan = null;
-    if (user.storage) {
+    if (user.storage?.plan) {
       storagePlan = await this.userService.getStoragePlanById(user.storage.plan);
     }
 

--- a/src/server/my-space-controller.js
+++ b/src/server/my-space-controller.js
@@ -1,15 +1,17 @@
 import PageRenderer from './page-renderer.js';
 import { PAGE_NAME } from '../domain/page-name.js';
 import RoomService from '../services/room-service.js';
+import UserService from '../services/user-service.js';
 import ServerConfig from '../bootstrap/server-config.js';
 import ClientDataMapper from '../server/client-data-mapper.js';
 import needsAuthentication from '../domain/needs-authentication-middleware.js';
 
 class UserController {
-  static get inject() { return [ServerConfig, PageRenderer, RoomService, ClientDataMapper]; }
+  static get inject() { return [ServerConfig, PageRenderer, UserService, RoomService, ClientDataMapper]; }
 
-  constructor(serverConfig, pageRenderer, roomService, clientDataMapper) {
+  constructor(serverConfig, pageRenderer, userService, roomService, clientDataMapper) {
     this.serverConfig = serverConfig;
+    this.userService = userService;
     this.roomService = roomService;
     this.pageRenderer = pageRenderer;
     this.clientDataMapper = clientDataMapper;
@@ -18,13 +20,18 @@ class UserController {
   async handleGetMySpacePage(req, res) {
     const { user } = req;
 
+    let storagePlan = null;
+    if (user.storage) {
+      storagePlan = await this.userService.getStoragePlanById(user.storage.plan);
+    }
+
     let rooms = [];
     if (this.serverConfig.areRoomsEnabled) {
       rooms = await this.roomService.getRoomsOwnedOrJoinedByUser(user._id);
     }
-
     const mappedRooms = await Promise.all(rooms.map(room => this.clientDataMapper.mapRoom(room, user)));
-    const initialState = { rooms: mappedRooms };
+
+    const initialState = { storagePlan, rooms: mappedRooms };
 
     return this.pageRenderer.sendPage(req, res, PAGE_NAME.mySpace, initialState);
   }

--- a/src/styles/antd-overrides.less
+++ b/src/styles/antd-overrides.less
@@ -529,7 +529,7 @@
 
 // // Progress
 // // --
-// @progress-default-color: @processing-color;
+@progress-default-color: @edu-progress-default-color;
 // @progress-remaining-color: @background-color-base;
 // @progress-info-text-color: @progress-text-color;
 // @progress-radius: 100px;

--- a/src/styles/global-variables.less
+++ b/src/styles/global-variables.less
@@ -51,6 +51,7 @@
 @edu-text-color-secondary: fade(@edu-black, 45%);
 @edu-text-color-inverse: @edu-white;
 @edu-selection-background-color: fade(@edu-primary-color, 10%);
+@edu-progress-default-color: fade(@edu-primary-color, 60%);
 
 // Slider
 @edu-slider-rail-background-color: @grey-4;

--- a/src/styles/main.less
+++ b/src/styles/main.less
@@ -62,6 +62,7 @@
 @import '../components/history-control-panel.less';
 @import '../components/section-display.less';
 @import '../components/lesson-metadata-modal.less';
+@import '../components/used-storage.less';
 
 // Pure CSS components
 @import '../styles/tabs.less';

--- a/src/ui/default-prop-types.js
+++ b/src/ui/default-prop-types.js
@@ -77,9 +77,18 @@ export const settingsProps = {
   settings: settingsShape.isRequired
 };
 
-export const storagePlanShape = PropTypes.shape({
+export const baseStoragePlanProps = {
   _id: PropTypes.string.isRequired,
   name: PropTypes.string.isRequired
+};
+
+export const baseStoragePlanShape = PropTypes.shape({
+  ...baseStoragePlanProps
+});
+
+export const storagePlanShape = PropTypes.shape({
+  ...baseStoragePlanProps,
+  maxSizeInBytes: PropTypes.number.isRequired
 });
 
 export const userProfileShape = PropTypes.shape({


### PR DESCRIPTION
Closes https://educandu.atlassian.net/browse/EDU-356

Decided to show this in a separate tab after all, due to the current form layout we have on the account tab.

_Example with < 95% occupied storage:_


<img width="846" alt="Screen Shot 2022-02-16 at 17 07 37" src="https://user-images.githubusercontent.com/8189923/154307728-58fb97e9-8dbc-42b6-be2d-7359c1db5abb.png">


_Example with >= 95% occupied storage:_


<img width="848" alt="Screen Shot 2022-02-16 at 17 07 59" src="https://user-images.githubusercontent.com/8189923/154307708-2a8f24a5-e18c-49b3-b09e-15a2fe89e2a2.png">
