### PR TITLE
EDU-427 Add latest user activities to dashboard

### DIFF
--- a/migrations/educandu-2022-03-09-01-add-updatedOn-to-rooms.js
+++ b/migrations/educandu-2022-03-09-01-add-updatedOn-to-rooms.js
@@ -1,0 +1,14 @@
+/* eslint-disable camelcase */
+export default class Educandu_2022_03_09_01_add_updatedOn_to_rooms {
+  constructor(db) {
+    this.db = db;
+  }
+
+  async up() {
+    await this.db.collection('rooms').update({}, [{ $set: { updatedOn: '$createdOn' } }], { multi: true });
+  }
+
+  async down() {
+    await this.db.collection('rooms').updateMany({}, { $unset: { updatedOn: null } });
+  }
+}

--- a/migrations/educandu-2022-03-10-01-add-activities-related-indexes.js
+++ b/migrations/educandu-2022-03-10-01-add-activities-related-indexes.js
@@ -1,0 +1,48 @@
+// eslint-disable-next-line camelcase
+export default class Educandu_2022_03_10_01_add_activities_related_indexes {
+  constructor(db) {
+    this.db = db;
+  }
+
+  async up() {
+    await this.db.collection('documents').createIndexes([
+      {
+        name: '_idx_createdBy_',
+        key: { createdBy: -1 }
+      },
+      {
+        name: '_idx_updatedBy_',
+        key: { updatedBy: -1 }
+      }
+    ]);
+    await this.db.collection('rooms').createIndexes([
+      {
+        name: '_idx_created_by_',
+        key: { createdBy: -1 }
+      },
+      {
+        name: '_idx_updated_by_',
+        key: { updatedBy: -1 }
+      },
+      {
+        name: '_idx_members_user_id_desc_',
+        key: { 'members.userId': -1 }
+      }
+    ]);
+    await this.db.collection('lessons').createIndexes([
+      {
+        name: '_idx_created_by_',
+        key: { createdBy: -1 }
+      }
+    ]);
+  }
+
+  async down() {
+    await this.db.collection('documents').dropIndex('_idx_createdBy_');
+    await this.db.collection('documents').dropIndex('_idx_updatedBy_');
+    await this.db.collection('rooms').dropIndex('_idx_createdBy_');
+    await this.db.collection('rooms').dropIndex('_idx_updatedBy_');
+    await this.db.collection('rooms').dropIndex('_idx_members_user_id_desc_');
+    await this.db.collection('lessons').dropIndex('_idx_createdBy_');
+  }
+}

--- a/src/components/metadata-title.less
+++ b/src/components/metadata-title.less
@@ -1,7 +1,7 @@
 .MetadataTitle {
   display: flex;
   align-items: baseline;
-  margin: 0 0 1em 0;
+  margin: 0 0 0.5em 0;
   padding: 0 0 0.25em 0;
   border-bottom: 1px solid @edu-border-color-base;
 }

--- a/src/components/news-tab.js
+++ b/src/components/news-tab.js
@@ -1,28 +1,17 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import urls from '../utils/urls.js';
 import { useTranslation } from 'react-i18next';
 import EditIcon from './icons/general/edit-icon.js';
 import { useDateFormat } from './locale-context.js';
 import { USER_ACTIVITY_TYPE } from '../domain/constants.js';
 import DuplicateIcon from './icons/general/duplicate-icon.js';
+import { userActivitiesShape } from '../ui/default-prop-types.js';
 import { StarFilled, UsergroupAddOutlined } from '@ant-design/icons';
 
-function NewsTab() {
+function NewsTab({ activities }) {
   const { formatDate } = useDateFormat();
   const { t } = useTranslation('newsTab');
-
-  const activities = [
-    { type: USER_ACTIVITY_TYPE.documentCreated, timestamp: new Date(), data: { title: 'My document', _id: '' } },
-    { type: USER_ACTIVITY_TYPE.documentUpdated, timestamp: new Date(), data: { title: 'My document', _id: '' } },
-    { type: USER_ACTIVITY_TYPE.documentMarkedFavorite, timestamp: new Date(), data: { title: 'Some document', _id: '' } },
-    { type: USER_ACTIVITY_TYPE.roomCreated, timestamp: new Date(), data: { title: 'My room', _id: '' } },
-    { type: USER_ACTIVITY_TYPE.roomUpdated, timestamp: new Date(), data: { title: 'My room', _id: '' } },
-    { type: USER_ACTIVITY_TYPE.roomMarkedFavorite, timestamp: new Date(), data: { title: 'Some room', _id: '' } },
-    { type: USER_ACTIVITY_TYPE.roomJoined, timestamp: new Date(), data: { title: 'Other room', _id: '' } },
-    { type: USER_ACTIVITY_TYPE.lessonCreated, timestamp: new Date(), data: { title: 'My lesson', _id: '' } },
-    { type: USER_ACTIVITY_TYPE.lessonUpdated, timestamp: new Date(), data: { title: 'My lesson', _id: '' } },
-    { type: USER_ACTIVITY_TYPE.lessonMarkedFavorite, timestamp: new Date(), data: { title: 'Some lesson', _id: '' } }
-  ];
 
   const renderActivity = ({ icon, timestamp, description, linkText, linkHref }) => (
     <div className="NewsTab-activity">
@@ -72,7 +61,7 @@ function NewsTab() {
       icon: <DuplicateIcon />,
       timestamp: activity.timestamp,
       description: t('roomCreatedActivity'),
-      linkText: activity.data.title,
+      linkText: activity.data.name,
       linkHref: urls.getRoomUrl(activity.data._id)
     });
   };
@@ -82,7 +71,7 @@ function NewsTab() {
       icon: <EditIcon />,
       timestamp: activity.timestamp,
       description: t('roomUpdatedActivity'),
-      linkText: activity.data.title,
+      linkText: activity.data.name,
       linkHref: urls.getRoomUrl(activity.data._id)
     });
   };
@@ -92,7 +81,7 @@ function NewsTab() {
       icon: <StarFilled className="NewsTab-activityMetadataIcon--lighter" />,
       timestamp: activity.timestamp,
       description: t('roomMarkedFavoriteActivity'),
-      linkText: activity.data.title,
+      linkText: activity.data.name,
       linkHref: urls.getRoomUrl(activity.data._id)
     });
   };
@@ -102,7 +91,7 @@ function NewsTab() {
       icon: <UsergroupAddOutlined />,
       timestamp: activity.timestamp,
       description: t('roomJoinedActivity'),
-      linkText: activity.data.title,
+      linkText: activity.data.name,
       linkHref: urls.getRoomUrl(activity.data._id)
     });
   };
@@ -113,7 +102,7 @@ function NewsTab() {
       timestamp: activity.timestamp,
       description: t('lessonCreatedActivity'),
       linkText: activity.data.title,
-      linkHref: urls.getLessonUrl(activity.data._id)
+      linkHref: urls.getLessonUrl({ id: activity.data._id })
     });
   };
 
@@ -123,7 +112,7 @@ function NewsTab() {
       timestamp: activity.timestamp,
       description: t('lessonUpdatedActivity'),
       linkText: activity.data.title,
-      linkHref: urls.getLessonUrl(activity.data._id)
+      linkHref: urls.getLessonUrl({ id: activity.data._id })
     });
   };
 
@@ -133,7 +122,7 @@ function NewsTab() {
       timestamp: activity.timestamp,
       description: t('lessonMarkedFavoriteActivity'),
       linkText: activity.data.title,
-      linkHref: urls.getLessonUrl(activity.data._id)
+      linkHref: urls.getLessonUrl({ id: activity.data._id })
     });
   };
 
@@ -166,18 +155,26 @@ function NewsTab() {
 
   const renderActivities = () => {
     return activities
-      .map(activity => <div key={activity.timestamp}>{renderActivityByType(activity)}</div>)
+      .map(activity => <div key={JSON.stringify(activity)}>{renderActivityByType(activity)}</div>)
       .filter(activity => activity);
   };
 
   return (
-    <section>
-      <h5 className="NewsTab-activitiesHeader">{t('latestActivitiesHeader')}</h5>
-      <div className="NewsTab-activities">
-        {renderActivities()}
-      </div>
-    </section>
+    <div>
+      {!!activities.length && (
+        <section>
+          <h5 className="NewsTab-activitiesHeader">{t('latestActivitiesHeader')}</h5>
+          <div className="NewsTab-activities">
+            {renderActivities()}
+          </div>
+        </section>
+      )}
+    </div>
   );
 }
+
+NewsTab.propTypes = {
+  activities: PropTypes.arrayOf(userActivitiesShape).isRequired
+};
 
 export default NewsTab;

--- a/src/components/news-tab.js
+++ b/src/components/news-tab.js
@@ -1,0 +1,183 @@
+import React from 'react';
+import urls from '../utils/urls.js';
+import { useTranslation } from 'react-i18next';
+import EditIcon from './icons/general/edit-icon.js';
+import { useDateFormat } from './locale-context.js';
+import { USER_ACTIVITY_TYPE } from '../domain/constants.js';
+import DuplicateIcon from './icons/general/duplicate-icon.js';
+import { StarFilled, UsergroupAddOutlined } from '@ant-design/icons';
+
+function NewsTab() {
+  const { formatDate } = useDateFormat();
+  const { t } = useTranslation('newsTab');
+
+  const activities = [
+    { type: USER_ACTIVITY_TYPE.documentCreated, timestamp: new Date(), data: { title: 'My document', _id: '' } },
+    { type: USER_ACTIVITY_TYPE.documentUpdated, timestamp: new Date(), data: { title: 'My document', _id: '' } },
+    { type: USER_ACTIVITY_TYPE.documentMarkedFavorite, timestamp: new Date(), data: { title: 'Some document', _id: '' } },
+    { type: USER_ACTIVITY_TYPE.roomCreated, timestamp: new Date(), data: { title: 'My room', _id: '' } },
+    { type: USER_ACTIVITY_TYPE.roomUpdated, timestamp: new Date(), data: { title: 'My room', _id: '' } },
+    { type: USER_ACTIVITY_TYPE.roomMarkedFavorite, timestamp: new Date(), data: { title: 'Some room', _id: '' } },
+    { type: USER_ACTIVITY_TYPE.roomJoined, timestamp: new Date(), data: { title: 'Other room', _id: '' } },
+    { type: USER_ACTIVITY_TYPE.lessonCreated, timestamp: new Date(), data: { title: 'My lesson', _id: '' } },
+    { type: USER_ACTIVITY_TYPE.lessonUpdated, timestamp: new Date(), data: { title: 'My lesson', _id: '' } },
+    { type: USER_ACTIVITY_TYPE.lessonMarkedFavorite, timestamp: new Date(), data: { title: 'Some lesson', _id: '' } }
+  ];
+
+  const renderActivity = ({ icon, timestamp, description, linkText, linkHref }) => (
+    <div className="NewsTab-activity">
+      <div className="NewsTab-activityMetadata">
+        <div className="NewsTab-activityMetadataIcon">{icon}</div>
+        <div>{formatDate(timestamp)}</div>
+      </div>
+      <div className="NewsTab-activityData">
+        <span className="NewsTab-activityDataDescription">{description}:</span>
+        <a className="NewsTab-activityDataLink" href={linkHref}>{linkText}</a>
+      </div>
+    </div>
+  );
+
+  const renderDocumentCreatedActivity = activity => {
+    return renderActivity({
+      icon: <DuplicateIcon />,
+      timestamp: activity.timestamp,
+      description: t('documentCreatedActivity'),
+      linkText: activity.data.title,
+      linkHref: urls.getDocUrl({ key: activity.data._id })
+    });
+  };
+
+  const renderDocumentUpdatedActivity = activity => {
+    return renderActivity({
+      icon: <EditIcon />,
+      timestamp: activity.timestamp,
+      description: t('documentUpdatedActivity'),
+      linkText: activity.data.title,
+      linkHref: urls.getDocUrl({ key: activity.data._id })
+    });
+  };
+
+  const renderDocumentMarkedFavoriteActivity = activity => {
+    return renderActivity({
+      icon: <StarFilled className="NewsTab-activityMetadataIcon--lighter" />,
+      timestamp: activity.timestamp,
+      description: t('documentMarkedFavoriteActivity'),
+      linkText: activity.data.title,
+      linkHref: urls.getDocUrl({ key: activity.data._id })
+    });
+  };
+
+  const renderRoomCreatedActivity = activity => {
+    return renderActivity({
+      icon: <DuplicateIcon />,
+      timestamp: activity.timestamp,
+      description: t('roomCreatedActivity'),
+      linkText: activity.data.title,
+      linkHref: urls.getRoomUrl(activity.data._id)
+    });
+  };
+
+  const renderRoomUpdatedActivity = activity => {
+    return renderActivity({
+      icon: <EditIcon />,
+      timestamp: activity.timestamp,
+      description: t('roomUpdatedActivity'),
+      linkText: activity.data.title,
+      linkHref: urls.getRoomUrl(activity.data._id)
+    });
+  };
+
+  const renderRoomMarkedFavoriteActivity = activity => {
+    return renderActivity({
+      icon: <StarFilled className="NewsTab-activityMetadataIcon--lighter" />,
+      timestamp: activity.timestamp,
+      description: t('roomMarkedFavoriteActivity'),
+      linkText: activity.data.title,
+      linkHref: urls.getRoomUrl(activity.data._id)
+    });
+  };
+
+  const renderRoomJoinedActivity = activity => {
+    return renderActivity({
+      icon: <UsergroupAddOutlined />,
+      timestamp: activity.timestamp,
+      description: t('roomJoinedActivity'),
+      linkText: activity.data.title,
+      linkHref: urls.getRoomUrl(activity.data._id)
+    });
+  };
+
+  const renderLessonCreatedActivity = activity => {
+    return renderActivity({
+      icon: <DuplicateIcon />,
+      timestamp: activity.timestamp,
+      description: t('lessonCreatedActivity'),
+      linkText: activity.data.title,
+      linkHref: urls.getLessonUrl(activity.data._id)
+    });
+  };
+
+  const renderLessonUpdatedActivity = activity => {
+    return renderActivity({
+      icon: <EditIcon />,
+      timestamp: activity.timestamp,
+      description: t('lessonUpdatedActivity'),
+      linkText: activity.data.title,
+      linkHref: urls.getLessonUrl(activity.data._id)
+    });
+  };
+
+  const renderLessonMarkedFavoriteActivity = activity => {
+    return renderActivity({
+      icon: <StarFilled className="NewsTab-activityMetadataIcon--lighter" />,
+      timestamp: activity.timestamp,
+      description: t('lessonMarkedFavoriteActivity'),
+      linkText: activity.data.title,
+      linkHref: urls.getLessonUrl(activity.data._id)
+    });
+  };
+
+  const renderActivityByType = activity => {
+    switch (activity.type) {
+      case USER_ACTIVITY_TYPE.documentCreated:
+        return renderDocumentCreatedActivity(activity);
+      case USER_ACTIVITY_TYPE.documentUpdated:
+        return renderDocumentUpdatedActivity(activity);
+      case USER_ACTIVITY_TYPE.documentMarkedFavorite:
+        return renderDocumentMarkedFavoriteActivity(activity);
+      case USER_ACTIVITY_TYPE.roomCreated:
+        return renderRoomCreatedActivity(activity);
+      case USER_ACTIVITY_TYPE.roomUpdated:
+        return renderRoomUpdatedActivity(activity);
+      case USER_ACTIVITY_TYPE.roomMarkedFavorite:
+        return renderRoomMarkedFavoriteActivity(activity);
+      case USER_ACTIVITY_TYPE.roomJoined:
+        return renderRoomJoinedActivity(activity);
+      case USER_ACTIVITY_TYPE.lessonCreated:
+        return renderLessonCreatedActivity(activity);
+      case USER_ACTIVITY_TYPE.lessonUpdated:
+        return renderLessonUpdatedActivity(activity);
+      case USER_ACTIVITY_TYPE.lessonMarkedFavorite:
+        return renderLessonMarkedFavoriteActivity(activity);
+      default:
+        return null;
+    }
+  };
+
+  const renderActivities = () => {
+    return activities
+      .map(activity => <div key={activity.timestamp}>{renderActivityByType(activity)}</div>)
+      .filter(activity => activity);
+  };
+
+  return (
+    <section>
+      <h5 className="NewsTab-activitiesHeader">{t('latestActivitiesHeader')}</h5>
+      <div className="NewsTab-activities">
+        {renderActivities()}
+      </div>
+    </section>
+  );
+}
+
+export default NewsTab;

--- a/src/components/news-tab.less
+++ b/src/components/news-tab.less
@@ -1,0 +1,62 @@
+@news-tab-activity-grid-gap: 20px;
+@news-tab-section-content-padding: 20px;
+
+.NewsTab-activitiesHeader {
+  color: @edu-text-color;
+}
+
+.NewsTab-activities {
+  padding: @news-tab-section-content-padding;
+
+  @media @edu-media-phone {
+    padding-left: 0;
+    padding-right: 0;
+  }
+}
+
+.NewsTab-activity {
+  display: grid;
+  grid-gap: @news-tab-activity-grid-gap;
+  align-items: center;
+  grid-auto-flow: column;
+  justify-content: flex-start;
+  padding: 15px 20px;
+  margin-bottom: 10px;
+  color: @edu-text-color-secondary;
+  border-radius: @edu-border-radius-base;
+  background-color: @edu-background-color-base;
+
+  @media @edu-media-phone {
+    grid-gap: 3px;
+    grid-auto-flow: row;
+  }
+}
+
+.NewsTab-activityMetadata {
+  display: grid;
+  grid-gap: @news-tab-activity-grid-gap;
+  align-items: center;
+  grid-auto-flow: column;
+  justify-content: flex-start;
+}
+
+.NewsTab-activityMetadataIcon {
+  color: @edu-black;
+
+  & > .NewsTab-activityMetadataIcon--lighter {
+    color: @edu-text-color-secondary;
+  }
+}
+
+.NewsTab-activityData {
+  display: flex;
+  flex-wrap: wrap;
+}
+
+.NewsTab-activityDataDescription {
+  margin-right: 5px;
+}
+
+.NewsTab-activityDataLink {
+  color: @edu-text-color;
+}

--- a/src/components/news-tab.yml
+++ b/src/components/news-tab.yml
@@ -1,0 +1,33 @@
+latestActivitiesHeader:
+  en: Latest activities
+  de: Letzte Aktivitäten
+documentCreatedActivity:
+  en: New document created
+  de: Neues Dokument erstellt
+documentUpdatedActivity:
+  en: Document updated
+  de: Dokument bearbeitet
+documentMarkedFavoriteActivity:
+  en: Document marked as favorite
+  de: Dokument als Favorit hinzugefügt
+roomCreatedActivity:
+  en: New room created
+  de: Neuen Raum ertellt
+roomUpdatedActivity:
+  en: Room updated
+  de: Raum bearbeitet
+roomMarkedFavoriteActivity:
+  en: Room marked as favorite
+  de: Raum als Favorit hinzugefügt
+roomJoinedActivity:
+  en: Private room joined
+  de: Privater Raum eingetreten
+lessonCreatedActivity:
+  en: New lesson created
+  de: Neue Unterrichtseinheit erstellt
+lessonUpdatedActivity:
+  en: Lesson updated
+  de: Unterrichtseinheit bearbeitet
+lessonMarkedFavoriteActivity:
+  en: Lesson marked as favorite
+  de: Unterrichtseinheit als Favorit hinzugefügt

--- a/src/components/news-tab.yml
+++ b/src/components/news-tab.yml
@@ -21,7 +21,7 @@ roomMarkedFavoriteActivity:
   de: Raum als Favorit hinzugefügt
 roomJoinedActivity:
   en: Private room joined
-  de: Privater Raum eingetreten
+  de: Privatem Raum beigetreten
 lessonCreatedActivity:
   en: New lesson created
   de: Neue Unterrichtseinheit erstellt

--- a/src/components/news-tab.yml
+++ b/src/components/news-tab.yml
@@ -12,7 +12,7 @@ documentMarkedFavoriteActivity:
   de: Dokument als Favorit hinzugefügt
 roomCreatedActivity:
   en: New room created
-  de: Neuen Raum ertellt
+  de: Neuen Raum erstellt
 roomUpdatedActivity:
   en: Room updated
   de: Raum bearbeitet

--- a/src/components/pages/dashboard.js
+++ b/src/components/pages/dashboard.js
@@ -2,6 +2,7 @@ import React from 'react';
 import gravatar from 'gravatar';
 import PropTypes from 'prop-types';
 import { Avatar, Tabs } from 'antd';
+import NewsTab from '../news-tab.js';
 import RoomsTab from '../rooms-tab.js';
 import AccountTab from '../account-tab.js';
 import ProfileTab from '../profile-tab.js';
@@ -69,19 +70,22 @@ function Dashboard({ initialState, PageTemplate }) {
           </div>
         </section>
 
-        <Tabs className="Tabs" defaultActiveKey="1" type="line" size="large">
+        <Tabs className="Tabs" defaultActiveKey="1" type="line" size="middle">
+          <TabPane className="Tabs-tabPane" tab={t('newsTabTitle')} key="1">
+            <NewsTab />
+          </TabPane>
           {clientConfig.areRoomsEnabled && (
-            <TabPane className="Tabs-tabPane" tab={t('roomsTabTitle')} key="1">
+            <TabPane className="Tabs-tabPane" tab={t('roomsTabTitle')} key="2">
               <RoomsTab rooms={rooms} />
             </TabPane>)}
-          <TabPane className="Tabs-tabPane" tab={t('profileTabTitle')} key="2">
+          <TabPane className="Tabs-tabPane" tab={t('profileTabTitle')} key="3">
             <ProfileTab formItemLayout={formItemLayout} tailFormItemLayout={tailFormItemLayout} />
           </TabPane>
-          <TabPane className="Tabs-tabPane" tab={t('accountTabTitle')} key="3">
+          <TabPane className="Tabs-tabPane" tab={t('accountTabTitle')} key="4">
             <AccountTab formItemLayout={formItemLayout} tailFormItemLayout={tailFormItemLayout} />
           </TabPane>
           {!!(user.storage.plan || user.storage.usedBytes) && (
-            <TabPane className="Tabs-tabPane" tab={t('common:storage')} key="4">
+            <TabPane className="Tabs-tabPane" tab={t('common:storage')} key="5">
               <h5>{storagePlanName}</h5>
               <div className="DashboardPage-usedStorage">
                 <UsedStorage usedBytes={user.storage.usedBytes} maxBytes={storagePlan?.maxBytes} showLabel />

--- a/src/components/pages/dashboard.js
+++ b/src/components/pages/dashboard.js
@@ -10,9 +10,9 @@ import { useUser } from '../user-context.js';
 import UsedStorage from '../used-storage.js';
 import { useTranslation } from 'react-i18next';
 import { useService } from '../container-context.js';
-import { roomShape } from '../../ui/default-prop-types.js';
 import ClientConfig from '../../bootstrap/client-config.js';
 import { useStoragePlan } from '../storage-plan-context.js';
+import { roomShape, userActivitiesShape } from '../../ui/default-prop-types.js';
 
 const { TabPane } = Tabs;
 
@@ -24,7 +24,7 @@ function Dashboard({ initialState, PageTemplate }) {
   const { t } = useTranslation('dashboard');
   const clientConfig = useService(ClientConfig);
 
-  const { rooms } = initialState;
+  const { rooms, activities } = initialState;
   const gravatarUrl = gravatar.url(user.email, { s: AVATAR_SIZE, d: 'mp' });
   const storagePlanName = storagePlan ? `"${storagePlan.name}" ${t('storagePlanLabel')}` : t('noStoragePlanLabel');
 
@@ -72,7 +72,7 @@ function Dashboard({ initialState, PageTemplate }) {
 
         <Tabs className="Tabs" defaultActiveKey="1" type="line" size="middle">
           <TabPane className="Tabs-tabPane" tab={t('newsTabTitle')} key="1">
-            <NewsTab />
+            <NewsTab activities={activities} />
           </TabPane>
           {clientConfig.areRoomsEnabled && (
             <TabPane className="Tabs-tabPane" tab={t('roomsTabTitle')} key="2">
@@ -102,7 +102,8 @@ function Dashboard({ initialState, PageTemplate }) {
 Dashboard.propTypes = {
   PageTemplate: PropTypes.func.isRequired,
   initialState: PropTypes.shape({
-    rooms: PropTypes.arrayOf(roomShape).isRequired
+    rooms: PropTypes.arrayOf(roomShape).isRequired,
+    activities: PropTypes.arrayOf(userActivitiesShape).isRequired
   }).isRequired
 };
 

--- a/src/components/pages/dashboard.yml
+++ b/src/components/pages/dashboard.yml
@@ -1,3 +1,6 @@
+newsTabTitle:
+  en: News
+  de: Neuigkeiten
 profileTabTitle:
   en: Profile
   de: Profil

--- a/src/components/pages/lesson.js
+++ b/src/components/pages/lesson.js
@@ -220,15 +220,13 @@ function Lesson({ PageTemplate, initialState }) {
     <Fragment>
       <PageTemplate>
         <div className="LessonPage">
-          <div className="LessonPage-breadcrumbs">
-            <Breadcrumb>
-              <Breadcrumb.Item href={urls.getRoomUrl(room._id, room.slug)}>
-                {isPrivateRoom ? <LockOutlined /> : <GlobalOutlined />}
-                <span>{room.name}</span>
-              </Breadcrumb.Item>
-              <Breadcrumb.Item>{lesson.title}</Breadcrumb.Item>
-            </Breadcrumb>
-          </div>
+          <Breadcrumb className="LessonPage-breadcrumbs">
+            <Breadcrumb.Item href={urls.getRoomUrl(room._id, room.slug)}>
+              {isPrivateRoom ? <LockOutlined /> : <GlobalOutlined />}
+              <span>{room.name}</span>
+            </Breadcrumb.Item>
+            <Breadcrumb.Item>{lesson.title}</Breadcrumb.Item>
+          </Breadcrumb>
           <MetadataTitle
             text={lesson.title}
             extra={<FavoriteStar type={FAVORITE_TYPE.lesson} id={lesson._id} />}

--- a/src/components/pages/lesson.less
+++ b/src/components/pages/lesson.less
@@ -1,7 +1,8 @@
 .LessonPage {}
 
 .LessonPage-breadcrumbs {
-  padding: @edu-content-padding 0;
+  font-size: 12px;
+  padding-bottom: 2 * @edu-content-padding;
 }
 
 .LessonPage-editControlPanelItem {

--- a/src/components/pages/room.js
+++ b/src/components/pages/room.js
@@ -236,7 +236,7 @@ export default function Room({ PageTemplate, initialState }) {
         {!isRoomOwner && renderRoomLessonsCard()}
 
         {isRoomOwner && (
-          <Tabs className="Tabs" defaultActiveKey="1" type="line" size="large">
+          <Tabs className="Tabs" defaultActiveKey="1" type="line" size="middle">
             <TabPane className="Tabs-tabPane" tab={t('lessonsTabTitle')} key="1">
               {renderRoomLessonsCard()}
             </TabPane>

--- a/src/components/pages/room.less
+++ b/src/components/pages/room.less
@@ -4,7 +4,8 @@
 
 .Room-subtitle {
   display: flex;
-  font-size: 13px;
+  font-size: 12px;
+  color: @edu-text-color-secondary;
 }
 
 .Room-subtitleIcon {

--- a/src/components/pages/users.js
+++ b/src/components/pages/users.js
@@ -463,7 +463,7 @@ function Users({ initialState, PageTemplate }) {
     <PageTemplate>
       <div className="UsersPage">
         <h1>{t('pageNames:users')}</h1>
-        <Tabs className="Tabs" defaultActiveKey={TABS.internalUsers} type="line" size="large" disabled={isSaving}>
+        <Tabs className="Tabs" defaultActiveKey={TABS.internalUsers} type="line" size="middle" disabled={isSaving}>
           <TabPane className="Tabs-tabPane" tab={t('internalUsers')} key={TABS.internalUsers}>
             <Table
               dataSource={internalUsers}

--- a/src/components/rooms-tab.js
+++ b/src/components/rooms-tab.js
@@ -1,9 +1,9 @@
 import by from 'thenby';
 import PropTypes from 'prop-types';
 import urls from '../utils/urls.js';
-import { Button, Table } from 'antd';
 import React, { useState } from 'react';
 import Restricted from './restricted.js';
+import { Button, Card, Table } from 'antd';
 import { useUser } from './user-context.js';
 import { useTranslation } from 'react-i18next';
 import { PlusOutlined } from '@ant-design/icons';
@@ -143,8 +143,7 @@ function RoomsTab({ rooms }) {
 
   return (
     <div className="RoomsTab">
-      <section className="RoomsTab-section">
-        <h2>{t('ownedRoomsHeader')}</h2>
+      <Card className="RoomsTab-card" title={t('ownedRoomsHeader')}>
         <Table dataSource={ownedRoomsRows} columns={ownedRoomsColumns} size="middle" />
         <Restricted to={permissions.OWN_ROOMS}>
           <Button
@@ -156,11 +155,10 @@ function RoomsTab({ rooms }) {
             className="RoomsTab-createRoomButton"
             />
         </Restricted>
-      </section>
-      <section className="RoomsTab-section">
-        <h2>{t('joinedRoomsHeader')}</h2>
+      </Card>
+      <Card className="RoomsTab-card" title={t('joinedRoomsHeader')}>
         <Table dataSource={membershipRoomsRows} columns={membershipRoomsColumns} size="middle" />
-      </section>
+      </Card>
       <RoomCreationModal isVisible={isRoomCreationModalVisible} onClose={handleRoomCreationModalClose} />
     </div>
   );

--- a/src/components/rooms-tab.less
+++ b/src/components/rooms-tab.less
@@ -1,12 +1,10 @@
-.RoomsTab {
-  padding-left: 30px;
-}
+.RoomsTab {}
 
-.RoomsTab-section {
-  padding-top: 60px;
+.RoomsTab-card {
+  margin-bottom: 60px;
 
-  &:first-of-type {
-    padding-top: 0;
+  &:last-of-type{
+    margin-bottom: 0;
   }
 }
 

--- a/src/domain/constants.js
+++ b/src/domain/constants.js
@@ -59,6 +59,19 @@ export const FAVORITE_TYPE = {
   room: 'room'
 };
 
+export const USER_ACTIVITY_TYPE = {
+  documentCreated: 'document-created',
+  documentUpdated: 'document-updated',
+  documentMarkedFavorite: 'document-marked-favorite',
+  roomCreated: 'room-created',
+  roomUpdated: 'room-updated',
+  roomMarkedFavorite: 'room-marked-favorite',
+  roomJoined: 'room-joined',
+  lessonCreated: 'lesson-created',
+  lessonUpdated: 'lesson-updated',
+  lessonMarkedFavorite: 'lesson-marked-favorite'
+};
+
 export const UI_LANGUAGE_COOKIE_NAME = 'UILANG';
 export const LOG_LEVEL_COOKIE_NAME = 'LOG_LEVEL';
 export const COOKIE_SAME_SITE_POLICY = 'lax';

--- a/src/resources/resources.json
+++ b/src/resources/resources.json
@@ -357,7 +357,7 @@
       "roomCreatedActivity": "Neuen Raum erstellt",
       "roomUpdatedActivity": "Raum bearbeitet",
       "roomMarkedFavoriteActivity": "Raum als Favorit hinzugefügt",
-      "roomJoinedActivity": "Privater Raum eingetreten",
+      "roomJoinedActivity": "Privatem Raum beigetreten",
       "lessonCreatedActivity": "Neue Unterrichtseinheit erstellt",
       "lessonUpdatedActivity": "Unterrichtseinheit bearbeitet",
       "lessonMarkedFavoriteActivity": "Unterrichtseinheit als Favorit hinzugefügt"

--- a/src/resources/resources.json
+++ b/src/resources/resources.json
@@ -330,6 +330,40 @@
     }
   },
   {
+    "namespace": "newsTab",
+    "language": "en",
+    "resources": {
+      "latestActivitiesHeader": "Latest activities",
+      "documentCreatedActivity": "New document created",
+      "documentUpdatedActivity": "Document updated",
+      "documentMarkedFavoriteActivity": "Document marked as favorite",
+      "roomCreatedActivity": "New room created",
+      "roomUpdatedActivity": "Room updated",
+      "roomMarkedFavoriteActivity": "Room marked as favorite",
+      "roomJoinedActivity": "Private room joined",
+      "lessonCreatedActivity": "New lesson created",
+      "lessonUpdatedActivity": "Lesson updated",
+      "lessonMarkedFavoriteActivity": "Lesson marked as favorite"
+    }
+  },
+  {
+    "namespace": "newsTab",
+    "language": "de",
+    "resources": {
+      "latestActivitiesHeader": "Letzte Aktivitäten",
+      "documentCreatedActivity": "Neues Dokument erstellt",
+      "documentUpdatedActivity": "Dokument bearbeitet",
+      "documentMarkedFavoriteActivity": "Dokument als Favorit hinzugefügt",
+      "roomCreatedActivity": "Neuen Raum ertellt",
+      "roomUpdatedActivity": "Raum bearbeitet",
+      "roomMarkedFavoriteActivity": "Raum als Favorit hinzugefügt",
+      "roomJoinedActivity": "Privater Raum eingetreten",
+      "lessonCreatedActivity": "Neue Unterrichtseinheit erstellt",
+      "lessonUpdatedActivity": "Unterrichtseinheit bearbeitet",
+      "lessonMarkedFavoriteActivity": "Unterrichtseinheit als Favorit hinzugefügt"
+    }
+  },
+  {
     "namespace": "notSupportedSection",
     "language": "en",
     "resources": {
@@ -405,6 +439,7 @@
     "namespace": "dashboard",
     "language": "en",
     "resources": {
+      "newsTabTitle": "News",
       "profileTabTitle": "Profile",
       "accountTabTitle": "Account",
       "roomsTabTitle": "Rooms",
@@ -416,6 +451,7 @@
     "namespace": "dashboard",
     "language": "de",
     "resources": {
+      "newsTabTitle": "Neuigkeiten",
       "profileTabTitle": "Profil",
       "accountTabTitle": "Konto",
       "roomsTabTitle": "Räume",

--- a/src/resources/resources.json
+++ b/src/resources/resources.json
@@ -354,7 +354,7 @@
       "documentCreatedActivity": "Neues Dokument erstellt",
       "documentUpdatedActivity": "Dokument bearbeitet",
       "documentMarkedFavoriteActivity": "Dokument als Favorit hinzugefügt",
-      "roomCreatedActivity": "Neuen Raum ertellt",
+      "roomCreatedActivity": "Neuen Raum erstellt",
       "roomUpdatedActivity": "Raum bearbeitet",
       "roomMarkedFavoriteActivity": "Raum als Favorit hinzugefügt",
       "roomJoinedActivity": "Privater Raum eingetreten",

--- a/src/server/dashboard-controller.js
+++ b/src/server/dashboard-controller.js
@@ -2,6 +2,7 @@ import PageRenderer from './page-renderer.js';
 import { PAGE_NAME } from '../domain/page-name.js';
 import RoomService from '../services/room-service.js';
 import ServerConfig from '../bootstrap/server-config.js';
+import { USER_ACTIVITY_TYPE } from '../domain/constants.js';
 import needsAuthentication from '../domain/needs-authentication-middleware.js';
 import ClientDataMappingService from '../services/client-data-mapping-service.js';
 
@@ -24,7 +25,20 @@ class UserController {
     }
     const mappedRooms = await Promise.all(rooms.map(room => this.clientDataMappingService.mapRoom(room, user)));
 
-    const initialState = { rooms: mappedRooms };
+    const activities = [
+      { type: USER_ACTIVITY_TYPE.documentCreated, timestamp: new Date().toISOString(), data: { title: 'My document', _id: '' } },
+      { type: USER_ACTIVITY_TYPE.documentUpdated, timestamp: new Date().toISOString(), data: { title: 'My document', _id: '' } },
+      { type: USER_ACTIVITY_TYPE.documentMarkedFavorite, timestamp: new Date().toISOString(), data: { title: 'Some document', _id: '' } },
+      { type: USER_ACTIVITY_TYPE.roomCreated, timestamp: new Date().toISOString(), data: { title: 'My room', _id: '' } },
+      { type: USER_ACTIVITY_TYPE.roomUpdated, timestamp: new Date().toISOString(), data: { title: 'My room', _id: '' } },
+      { type: USER_ACTIVITY_TYPE.roomMarkedFavorite, timestamp: new Date().toISOString(), data: { title: 'Some room', _id: '' } },
+      { type: USER_ACTIVITY_TYPE.roomJoined, timestamp: new Date().toISOString(), data: { title: 'Other room', _id: '' } },
+      { type: USER_ACTIVITY_TYPE.lessonCreated, timestamp: new Date().toISOString(), data: { title: 'My lesson', _id: '' } },
+      { type: USER_ACTIVITY_TYPE.lessonUpdated, timestamp: new Date().toISOString(), data: { title: 'My lesson', _id: '' } },
+      { type: USER_ACTIVITY_TYPE.lessonMarkedFavorite, timestamp: new Date().toISOString(), data: { title: 'Some lesson', _id: '' } }
+    ];
+
+    const initialState = { rooms: mappedRooms, activities };
 
     return this.pageRenderer.sendPage(req, res, PAGE_NAME.dashboard, initialState);
   }

--- a/src/server/dashboard-controller.js
+++ b/src/server/dashboard-controller.js
@@ -1,8 +1,8 @@
 import PageRenderer from './page-renderer.js';
 import { PAGE_NAME } from '../domain/page-name.js';
 import RoomService from '../services/room-service.js';
-import DashboardService from './dashboard-service.js';
 import ServerConfig from '../bootstrap/server-config.js';
+import DashboardService from '../services/dashboard-service.js';
 import needsAuthentication from '../domain/needs-authentication-middleware.js';
 import ClientDataMappingService from '../services/client-data-mapping-service.js';
 

--- a/src/server/dashboard-controller.js
+++ b/src/server/dashboard-controller.js
@@ -1,18 +1,19 @@
 import PageRenderer from './page-renderer.js';
 import { PAGE_NAME } from '../domain/page-name.js';
 import RoomService from '../services/room-service.js';
+import DashboardService from './dashboard-service.js';
 import ServerConfig from '../bootstrap/server-config.js';
-import { USER_ACTIVITY_TYPE } from '../domain/constants.js';
 import needsAuthentication from '../domain/needs-authentication-middleware.js';
 import ClientDataMappingService from '../services/client-data-mapping-service.js';
 
 class UserController {
-  static get inject() { return [ServerConfig, PageRenderer, RoomService, ClientDataMappingService]; }
+  static get inject() { return [ServerConfig, PageRenderer, DashboardService, RoomService, ClientDataMappingService]; }
 
-  constructor(serverConfig, pageRenderer, roomService, clientDataMappingService) {
-    this.serverConfig = serverConfig;
+  constructor(serverConfig, pageRenderer, dashboardService, roomService, clientDataMappingService) {
     this.roomService = roomService;
+    this.serverConfig = serverConfig;
     this.pageRenderer = pageRenderer;
+    this.dashboardService = dashboardService;
     this.clientDataMappingService = clientDataMappingService;
   }
 
@@ -24,21 +25,10 @@ class UserController {
       rooms = await this.roomService.getRoomsOwnedOrJoinedByUser(user._id);
     }
     const mappedRooms = await Promise.all(rooms.map(room => this.clientDataMappingService.mapRoom(room, user)));
+    const activities = await this.dashboardService.getUserActivities({ userId: user._id, limit: 10 });
+    const mappedActivities = this.clientDataMappingService.mapUserActivities(activities);
 
-    const activities = [
-      { type: USER_ACTIVITY_TYPE.documentCreated, timestamp: new Date().toISOString(), data: { title: 'My document', _id: '' } },
-      { type: USER_ACTIVITY_TYPE.documentUpdated, timestamp: new Date().toISOString(), data: { title: 'My document', _id: '' } },
-      { type: USER_ACTIVITY_TYPE.documentMarkedFavorite, timestamp: new Date().toISOString(), data: { title: 'Some document', _id: '' } },
-      { type: USER_ACTIVITY_TYPE.roomCreated, timestamp: new Date().toISOString(), data: { title: 'My room', _id: '' } },
-      { type: USER_ACTIVITY_TYPE.roomUpdated, timestamp: new Date().toISOString(), data: { title: 'My room', _id: '' } },
-      { type: USER_ACTIVITY_TYPE.roomMarkedFavorite, timestamp: new Date().toISOString(), data: { title: 'Some room', _id: '' } },
-      { type: USER_ACTIVITY_TYPE.roomJoined, timestamp: new Date().toISOString(), data: { title: 'Other room', _id: '' } },
-      { type: USER_ACTIVITY_TYPE.lessonCreated, timestamp: new Date().toISOString(), data: { title: 'My lesson', _id: '' } },
-      { type: USER_ACTIVITY_TYPE.lessonUpdated, timestamp: new Date().toISOString(), data: { title: 'My lesson', _id: '' } },
-      { type: USER_ACTIVITY_TYPE.lessonMarkedFavorite, timestamp: new Date().toISOString(), data: { title: 'Some lesson', _id: '' } }
-    ];
-
-    const initialState = { rooms: mappedRooms, activities };
+    const initialState = { rooms: mappedRooms, activities: mappedActivities };
 
     return this.pageRenderer.sendPage(req, res, PAGE_NAME.dashboard, initialState);
   }

--- a/src/server/dashboard-service.js
+++ b/src/server/dashboard-service.js
@@ -1,0 +1,134 @@
+import by from 'thenby';
+import RoomStore from '../stores/room-store.js';
+import UserStore from '../stores/user-store.js';
+import LessonStore from '../stores/lesson-store.js';
+import DocumentStore from '../stores/document-store.js';
+import { FAVORITE_TYPE, USER_ACTIVITY_TYPE } from '../domain/constants.js';
+
+class DashboardService {
+  static get inject() { return [UserStore, DocumentStore, RoomStore, LessonStore]; }
+
+  constructor(userStore, documentStore, roomStore, lessonStore) {
+    this.userStore = userStore;
+    this.roomStore = roomStore;
+    this.lessonStore = lessonStore;
+    this.documentStore = documentStore;
+  }
+
+  async getUserActivities({ userId, limit }) {
+    const user = await this.userStore.getUserById(userId);
+
+    const createdRooms = await this.roomStore.getRoomsCreatedByUser(userId);
+    const joinedRooms = await this.roomStore.getRoomsJoinedByUser(userId);
+    const updatedRooms = await this.roomStore.getRoomsUpdatedByUser(userId);
+    const createdDocuments = await this.documentStore.getDocumentsMetadataByCreatedBy(userId);
+    const updatedDocuments = await this.documentStore.getDocumentsMetadataByUpdatedBy(userId);
+    const lessons = await this.lessonStore.getLessonsMetadataByCreatedBy(createdRooms.map(room => room._id));
+
+    const createdDocumentActivities = createdDocuments.map(document => ({
+      type: USER_ACTIVITY_TYPE.documentCreated,
+      timestamp: document.createdOn,
+      data: { _id: document._id, title: document.title }
+    }));
+
+    const updatedDocumentActivities = updatedDocuments.map(document => ({
+      type: USER_ACTIVITY_TYPE.documentUpdated,
+      timestamp: document.updatedOn,
+      data: { _id: document._id, title: document.title }
+    }));
+
+    const createdRoomActivities = createdRooms.map(room => ({
+      type: USER_ACTIVITY_TYPE.roomCreated,
+      timestamp: room.createdOn,
+      data: { _id: room._id, name: room.name }
+    }));
+
+    const updatedRoomActivities = updatedRooms.map(room => ({
+      type: USER_ACTIVITY_TYPE.roomUpdated,
+      timestamp: room.updatedOn,
+      data: { _id: room._id, name: room.name }
+    }));
+
+    const joinedRoomActivities = joinedRooms.map(room => ({
+      type: USER_ACTIVITY_TYPE.roomJoined,
+      timestamp: room.members.find(member => member.userId === userId).joinedOn,
+      data: { _id: room._id, name: room.name }
+    }));
+
+    const lessonActivities = lessons.map(lesson => {
+      return lesson.createdOn === lesson.updatedOn
+        ? {
+          type: USER_ACTIVITY_TYPE.lessonCreated,
+          timestamp: lesson.createdOn,
+          data: { _id: lesson._id, title: lesson.title }
+        }
+        : {
+          type: USER_ACTIVITY_TYPE.lessonUpdated,
+          timestamp: lesson.updatedOn,
+          data: { _id: lesson._id, title: lesson.title }
+        };
+    });
+
+    const favoriteActivitiesMetadata = user.favorites.map(favorite => {
+      switch (favorite.type) {
+        case FAVORITE_TYPE.document:
+          return {
+            type: USER_ACTIVITY_TYPE.documentMarkedFavorite,
+            timestamp: favorite.setOn,
+            getData: async () => {
+              const document = await this.documentStore.getDocumentMetadataByKey(favorite.id);
+              return { _id: favorite.id, title: document.title };
+            }
+          };
+        case FAVORITE_TYPE.room:
+          return {
+            type: USER_ACTIVITY_TYPE.roomMarkedFavorite,
+            timestamp: favorite.setOn,
+            getData: async () => {
+              const room = await this.roomStore.getRoomById(favorite.id);
+              return { _id: favorite.id, name: room.name };
+            }
+          };
+        case FAVORITE_TYPE.lesson:
+          return {
+            type: USER_ACTIVITY_TYPE.lessonMarkedFavorite,
+            timestamp: favorite.setOn,
+            getData: async () => {
+              const lesson = await this.lessonStore.getLessonMetadataById(favorite.id);
+              return { _id: favorite.id, title: lesson.title };
+            }
+          };
+        default:
+          return null;
+      }
+    });
+
+    const incompleteActivities = [
+      ...createdDocumentActivities,
+      ...updatedDocumentActivities,
+      ...createdRoomActivities,
+      ...updatedRoomActivities,
+      ...joinedRoomActivities,
+      ...lessonActivities,
+      ...favoriteActivitiesMetadata
+    ]
+      .sort(by(item => item.timestamp, 'desc'))
+      .slice(0, limit);
+
+    const activities = [];
+    for (const activity of incompleteActivities) {
+      if (activity.getData) {
+        // eslint-disable-next-line no-await-in-loop
+        const data = await activity.getData();
+        delete activity.getData;
+        activities.push({ ...activity, data: { ...data } });
+      } else {
+        activities.push(activity);
+      }
+    }
+
+    return activities;
+  }
+}
+
+export default DashboardService;

--- a/src/services/client-data-mapping-service.js
+++ b/src/services/client-data-mapping-service.js
@@ -133,6 +133,10 @@ class ClientDataMappingService {
     return lessons.map(lesson => this._mapLessonMetadata(lesson));
   }
 
+  mapUserActivities(activities) {
+    return activities.map(activity => ({ ...activity, timestamp: activity.timestamp.toISOString() }));
+  }
+
   _mapUser(user, allowedUserFields) {
     if (!user) {
       return null;

--- a/src/services/dashboard-service.js
+++ b/src/services/dashboard-service.js
@@ -21,9 +21,9 @@ class DashboardService {
     const createdRooms = await this.roomStore.getRoomsCreatedByUser(userId);
     const joinedRooms = await this.roomStore.getRoomsJoinedByUser(userId);
     const updatedRooms = await this.roomStore.getRoomsUpdatedByUser(userId);
-    const createdDocuments = await this.documentStore.getDocumentsMetadataByCreatedBy(userId);
-    const updatedDocuments = await this.documentStore.getDocumentsMetadataByUpdatedBy(userId);
-    const lessons = await this.lessonStore.getLessonsMetadataByCreatedBy(userId);
+    const createdDocuments = await this.documentStore.getDocumentsMetadataCreatedByUser(userId);
+    const updatedDocuments = await this.documentStore.getDocumentsMetadataUpdatedByUser(userId);
+    const lessons = await this.lessonStore.getLessonsMetadataCreatedByUser(userId);
 
     const createdDocumentActivities = createdDocuments.map(document => ({
       type: USER_ACTIVITY_TYPE.documentCreated,

--- a/src/services/dashboard-service.js
+++ b/src/services/dashboard-service.js
@@ -15,15 +15,15 @@ class DashboardService {
     this.documentStore = documentStore;
   }
 
-  async getUserActivities({ userId, limit = 0 }) {
+  async getUserActivities({ userId, limit = 30 }) {
     const user = await this.userStore.getUserById(userId);
 
-    const createdRooms = await this.roomStore.getRoomsCreatedByUser(userId);
-    const joinedRooms = await this.roomStore.getRoomsJoinedByUser(userId);
-    const updatedRooms = await this.roomStore.getRoomsUpdatedByUser(userId);
-    const createdDocuments = await this.documentStore.getDocumentsMetadataCreatedByUser(userId);
-    const updatedDocuments = await this.documentStore.getDocumentsMetadataUpdatedByUser(userId);
-    const lessons = await this.lessonStore.getLessonsMetadataCreatedByUser(userId);
+    const createdRooms = await this.roomStore.getLatestRoomsCreatedByUser(userId, { limit });
+    const joinedRooms = await this.roomStore.getLatestRoomsJoinedByUser(userId, { limit });
+    const updatedRooms = await this.roomStore.getLatestRoomsUpdatedByUser(userId, { limit });
+    const createdDocuments = await this.documentStore.getLatestDocumentsMetadataCreatedByUser(userId, { limit });
+    const updatedDocuments = await this.documentStore.getLatestDocumentsMetadataUpdatedByUser(userId, { limit });
+    const lessons = await this.lessonStore.getLatestLessonsMetadataCreatedByUser(userId, { limit });
 
     const createdDocumentActivities = createdDocuments.map(document => ({
       type: USER_ACTIVITY_TYPE.documentCreated,
@@ -72,7 +72,8 @@ class DashboardService {
       }
     });
 
-    const favoriteActivitiesMetadata = user.favorites.map(favorite => {
+    const latestFavorites = user.favorites.sort(by(f => f.setOn, 'desc')).slice(0, limit);
+    const favoriteActivitiesMetadata = latestFavorites.map(favorite => {
       switch (favorite.type) {
         case FAVORITE_TYPE.document:
           return {

--- a/src/services/dashboard-service.spec.js
+++ b/src/services/dashboard-service.spec.js
@@ -1,0 +1,259 @@
+import Database from '../stores/database.js';
+import DashboardService from './dashboard-service.js';
+import { FAVORITE_TYPE, USER_ACTIVITY_TYPE } from '../domain/constants.js';
+import {
+  createTestDocument,
+  createTestLesson,
+  createTestRoom,
+  destroyTestEnvironment,
+  pruneTestEnvironment,
+  setupTestEnvironment,
+  setupTestUser
+} from '../test-helper.js';
+
+describe('dashboard-service', () => {
+  let db;
+  let sut;
+  let user;
+  let result;
+  let container;
+  let otherUser;
+
+  beforeAll(async () => {
+    container = await setupTestEnvironment();
+
+    db = container.get(Database);
+    sut = container.get(DashboardService);
+  });
+
+  afterAll(async () => {
+    await destroyTestEnvironment(container);
+  });
+
+  beforeEach(async () => {
+    user = await setupTestUser(container, { username: 'user', email: 'user@test.com' });
+    otherUser = await setupTestUser(container, { username: 'other', email: 'other@test.com' });
+  });
+
+  afterEach(async () => {
+    await pruneTestEnvironment(container);
+  });
+
+  describe('getUserActivities', () => {
+    describe('when there are no activities', () => {
+      beforeEach(async () => {
+        result = await sut.getUserActivities({ userId: user._id });
+      });
+
+      it('should return an empty array', () => {
+        expect(result).toEqual([]);
+      });
+    });
+
+    describe('when there are activities', () => {
+      let joinedRoom;
+      let createdRoom;
+      let favoriteRoom;
+      let createdLesson;
+      let favoriteLesson;
+      let createdDocument;
+      let updatedDocument;
+      let favoriteDocument;
+      let allUserActivities;
+
+      beforeEach(async () => {
+        createdDocument = await createTestDocument(container, user, { createdBy: user._id, title: 'Created document' });
+        await db.documents.updateOne({ _id: createdDocument._id }, {
+          $set: {
+            createdOn: new Date('2022-03-09T10:00:00.000Z'),
+            updatedOn: new Date('2022-03-09T10:00:00.000Z')
+          }
+        });
+
+        updatedDocument = await createTestDocument(container, otherUser, { title: 'Created document [other]' });
+        await db.documents.updateOne({ _id: updatedDocument._id }, {
+          $set: {
+            updatedBy: user._id,
+            title: 'Updated document',
+            createdOn: new Date('2022-03-09T10:00:00.000Z'),
+            updatedOn: new Date('2022-03-09T10:01:00.000Z')
+          }
+        });
+
+        createdRoom = await createTestRoom(container, {
+          owner: user._id,
+          createdBy: user._id,
+          name: 'Created room',
+          createdOn: new Date('2022-03-09T10:03:00.000Z'),
+          updatedOn: new Date('2022-03-09T10:03:00.000Z'),
+          members: [{ userId: otherUser._id, joinedOn: new Date('2022-03-09T10:04:00.000Z') }]
+        });
+        await db.rooms.updateOne({ _id: createdRoom._id }, {
+          $set: {
+            updatedBy: user._id,
+            name: 'Updated room',
+            createdOn: new Date('2022-03-09T10:03:00.000Z'),
+            updatedOn: new Date('2022-03-09T10:05:00.000Z')
+          }
+        });
+
+        joinedRoom = await createTestRoom(container, {
+          owner: otherUser._id,
+          createdBy: otherUser._id,
+          name: 'Created room [other]',
+          createdOn: new Date('2022-03-09T10:06:00.000Z'),
+          updatedOn: new Date('2022-03-09T10:06:00.000Z'),
+          members: [{ userId: user._id, joinedOn: new Date('2022-03-09T10:07:00.000Z') }]
+        });
+
+        createdLesson = await createTestLesson(container, {
+          createdBy: user._id,
+          title: 'Created lesson',
+          createdOn: new Date('2022-03-09T10:08:00.000Z'),
+          updatedOn: new Date('2022-03-09T10:08:00.000Z')
+        });
+        await db.lessons.updateOne({ _id: createdLesson._id }, {
+          $set: {
+            title: 'Updated lesson',
+            createdOn: new Date('2022-03-09T10:08:00.000Z'),
+            updatedOn: new Date('2022-03-09T10:09:00.000Z')
+          }
+        });
+        await createTestLesson(container, {
+          createdBy: otherUser._id,
+          title: 'Created lesson [other]',
+          createdOn: new Date('2022-03-09T10:10:00.000Z'),
+          updatedOn: new Date('2022-03-09T10:10:00.000Z')
+        });
+
+        favoriteRoom = await createTestRoom(container, { name: 'Created popular room [other]', owner: otherUser._id, createdBy: otherUser._id });
+        favoriteLesson = await createTestLesson(container, { title: 'Created popular lesson [other]', createdBy: otherUser._id });
+        favoriteDocument = await createTestDocument(container, otherUser, { title: 'Created popular document [other]' });
+        await db.users.updateOne({ _id: user._id }, {
+          $set: {
+            favorites: [
+              {
+                type: FAVORITE_TYPE.room,
+                setOn: new Date('2022-03-09T10:11:00.000Z'),
+                id: favoriteRoom._id
+              },
+              {
+                type: FAVORITE_TYPE.lesson,
+                setOn: new Date('2022-03-09T10:12:00.000Z'),
+                id: favoriteLesson._id
+              },
+              {
+                type: FAVORITE_TYPE.document,
+                setOn: new Date('2022-03-09T10:13:00.000Z'),
+                id: favoriteDocument._id
+              }
+            ]
+          }
+        });
+
+        allUserActivities = [
+          {
+            type: USER_ACTIVITY_TYPE.documentMarkedFavorite,
+            timestamp: new Date('2022-03-09T10:13:00.000Z'),
+            data: {
+              _id: favoriteDocument._id,
+              title: 'Created popular document [other]'
+            }
+          },
+          {
+            type: USER_ACTIVITY_TYPE.lessonMarkedFavorite,
+            timestamp: new Date('2022-03-09T10:12:00.000Z'),
+            data: {
+              _id: favoriteLesson._id,
+              title: 'Created popular lesson [other]'
+            }
+          },
+          {
+            type: USER_ACTIVITY_TYPE.roomMarkedFavorite,
+            timestamp: new Date('2022-03-09T10:11:00.000Z'),
+            data: {
+              _id: favoriteRoom._id,
+              name: 'Created popular room [other]'
+            }
+          },
+          {
+            type: USER_ACTIVITY_TYPE.lessonUpdated,
+            timestamp: new Date('2022-03-09T10:09:00.000Z'),
+            data: {
+              _id: createdLesson._id,
+              title: 'Updated lesson'
+            }
+          },
+          {
+            type: USER_ACTIVITY_TYPE.lessonCreated,
+            timestamp: new Date('2022-03-09T10:08:00.000Z'),
+            data: {
+              _id: createdLesson._id,
+              title: 'Updated lesson'
+            }
+          },
+          {
+            type: USER_ACTIVITY_TYPE.roomJoined,
+            timestamp: new Date('2022-03-09T10:07:00.000Z'),
+            data: {
+              _id: joinedRoom._id,
+              name: 'Created room [other]'
+            }
+          },
+          {
+            type: USER_ACTIVITY_TYPE.roomUpdated,
+            timestamp: new Date('2022-03-09T10:05:00.000Z'),
+            data: {
+              _id: createdRoom._id,
+              name: 'Updated room'
+            }
+          },
+          {
+            type: USER_ACTIVITY_TYPE.roomCreated,
+            timestamp: new Date('2022-03-09T10:03:00.000Z'),
+            data: {
+              _id: createdRoom._id,
+              name: 'Updated room'
+            }
+          },
+          {
+            type: USER_ACTIVITY_TYPE.documentUpdated,
+            timestamp: new Date('2022-03-09T10:01:00.000Z'),
+            data: {
+              _id: updatedDocument._id,
+              title: 'Updated document'
+            }
+          },
+          {
+            type: USER_ACTIVITY_TYPE.documentCreated,
+            timestamp: new Date('2022-03-09T10:00:00.000Z'),
+            data: {
+              _id: createdDocument._id,
+              title: 'Created document'
+            }
+          }
+        ];
+      });
+
+      describe('and limit is not set', () => {
+        beforeEach(async () => {
+          result = await sut.getUserActivities({ userId: user._id });
+        });
+
+        it('should return all activities sorted descending', () => {
+          expect(result).toEqual(allUserActivities);
+        });
+      });
+
+      describe('and limit is set to 5', () => {
+        beforeEach(async () => {
+          result = await sut.getUserActivities({ userId: user._id, limit: 5 });
+        });
+
+        it('should return latest 5 activities sorted descending', () => {
+          expect(result).toEqual(allUserActivities.splice(0, 5));
+        });
+      });
+    });
+  });
+});

--- a/src/services/room-service.js
+++ b/src/services/room-service.js
@@ -57,6 +57,7 @@ export default class RoomService {
       owner: user._id,
       createdBy: user._id,
       createdOn: new Date(),
+      updatedOn: new Date(),
       members: []
     };
 
@@ -68,7 +69,8 @@ export default class RoomService {
     const updatedRoom = {
       ...room,
       slug: room.slug || '',
-      description: room.description || ''
+      description: room.description || '',
+      updatedOn: new Date()
     };
     await this.roomStore.saveRoom(updatedRoom);
     return updatedRoom;

--- a/src/services/room-service.spec.js
+++ b/src/services/room-service.spec.js
@@ -74,6 +74,7 @@ describe('room-service', () => {
         description: '',
         createdOn: now,
         createdBy: myUser._id,
+        updatedOn: now,
         members: []
       });
     });

--- a/src/stores/collection-specs/documents.js
+++ b/src/stores/collection-specs/documents.js
@@ -2,6 +2,14 @@ export default {
   name: 'documents',
   indexes: [
     {
+      name: '_idx_createdBy_',
+      key: { createdBy: -1 }
+    },
+    {
+      name: '_idx_updatedBy_',
+      key: { updatedBy: -1 }
+    },
+    {
       name: '_idx_updatedOn_',
       key: { updatedOn: -1 }
     },

--- a/src/stores/collection-specs/lessons.js
+++ b/src/stores/collection-specs/lessons.js
@@ -4,6 +4,10 @@ export default {
     {
       name: '_idx_roomId_',
       key: { roomId: 1 }
+    },
+    {
+      name: '_idx_created_by_',
+      key: { createdBy: -1 }
     }
   ]
 };

--- a/src/stores/collection-specs/rooms.js
+++ b/src/stores/collection-specs/rooms.js
@@ -6,8 +6,20 @@ export default {
       key: { owner: 1 }
     },
     {
+      name: '_idx_created_by_',
+      key: { createdBy: -1 }
+    },
+    {
+      name: '_idx_updated_by_',
+      key: { updatedBy: -1 }
+    },
+    {
       name: '_idx_members_user_id_',
       key: { 'members.userId': 1 }
+    },
+    {
+      name: '_idx_members_user_id_desc_',
+      key: { 'members.userId': -1 }
     }
   ]
 };

--- a/src/stores/document-store.js
+++ b/src/stores/document-store.js
@@ -77,14 +77,14 @@ class DocumentStore {
     ).toArray();
   }
 
-  getDocumentsMetadataByCreatedBy(createdBy, { session } = {}) {
+  getDocumentsMetadataCreatedByUser(createdBy, { session } = {}) {
     return this.collection.find(
       { createdBy },
       { projection: documentMetadataProjection, session }
     ).toArray();
   }
 
-  getDocumentsMetadataByUpdatedBy(updatedBy, { session } = {}) {
+  getDocumentsMetadataUpdatedByUser(updatedBy, { session } = {}) {
     return this.collection.find(
       { $and: [{ updatedBy }, { $expr: { $ne: ['$createdOn', '$updatedOn'] } }] },
       { projection: documentMetadataProjection, session }

--- a/src/stores/document-store.js
+++ b/src/stores/document-store.js
@@ -86,7 +86,7 @@ class DocumentStore {
 
   getDocumentsMetadataByUpdatedBy(updatedBy, { session } = {}) {
     return this.collection.find(
-      { updatedBy },
+      { $and: [{ updatedBy }, { $expr: { $ne: ['$createdOn', '$updatedOn'] } }] },
       { projection: documentMetadataProjection, session }
     ).toArray();
   }

--- a/src/stores/document-store.js
+++ b/src/stores/document-store.js
@@ -77,18 +77,18 @@ class DocumentStore {
     ).toArray();
   }
 
-  getDocumentsMetadataCreatedByUser(createdBy, { session } = {}) {
+  getLatestDocumentsMetadataCreatedByUser(createdBy, { session, limit } = {}) {
     return this.collection.find(
       { createdBy },
       { projection: documentMetadataProjection, session }
-    ).toArray();
+    ).sort({ createdOn: -1 }).limit(limit || 0).toArray();
   }
 
-  getDocumentsMetadataUpdatedByUser(updatedBy, { session } = {}) {
+  getLatestDocumentsMetadataUpdatedByUser(updatedBy, { session, limit } = {}) {
     return this.collection.find(
       { $and: [{ updatedBy }, { $expr: { $ne: ['$createdOn', '$updatedOn'] } }] },
       { projection: documentMetadataProjection, session }
-    ).toArray();
+    ).sort({ updatedOn: -1 }).limit(limit || 0).toArray();
   }
 
   saveDocument(document, { session } = {}) {

--- a/src/stores/document-store.js
+++ b/src/stores/document-store.js
@@ -5,6 +5,7 @@ import { documentDBSchema } from '../domain/schemas/document-schemas.js';
 const documentMetadataProjection = {
   key: 1,
   revision: 1,
+  createdOn: 1,
   updatedOn: 1,
   title: 1,
   slug: 1,
@@ -41,6 +42,10 @@ class DocumentStore {
     return this.collection.findOne({ key }, { session });
   }
 
+  getDocumentMetadataByKey(key, { session } = {}) {
+    return this.collection.findOne({ key }, { projection: documentMetadataProjection, session });
+  }
+
   getAllDocumentRevisionsByKey(documentKey, { session } = {}) {
     return this.collection.find({ key: documentKey }, { sort: [['order', 1]], session }).toArray();
   }
@@ -68,6 +73,20 @@ class DocumentStore {
   getNonArchivedDocumentsMetadataByOrigin(origin, { session } = {}) {
     return this.collection.find(
       { archived: false, origin },
+      { projection: documentMetadataProjection, session }
+    ).toArray();
+  }
+
+  getDocumentsMetadataByCreatedBy(createdBy, { session } = {}) {
+    return this.collection.find(
+      { createdBy },
+      { projection: documentMetadataProjection, session }
+    ).toArray();
+  }
+
+  getDocumentsMetadataByUpdatedBy(updatedBy, { session } = {}) {
+    return this.collection.find(
+      { updatedBy },
       { projection: documentMetadataProjection, session }
     ).toArray();
   }

--- a/src/stores/lesson-store.js
+++ b/src/stores/lesson-store.js
@@ -8,7 +8,9 @@ const lessonMetadataProjection = {
   title: 1,
   slug: 1,
   language: 1,
-  schedule: 1
+  schedule: 1,
+  createdOn: 1,
+  updatedOn: 1
 };
 
 class LessonStore {
@@ -22,12 +24,20 @@ class LessonStore {
     return this.collection.findOne({ _id: lessonId }, { session });
   }
 
+  getLessonMetadataById(lessonId, { session } = {}) {
+    return this.collection.findOne({ _id: lessonId }, { projection: lessonMetadataProjection, session });
+  }
+
   getLessonsById(lessonIds, { session } = {}) {
     return this.collection.find({ _id: { $in: lessonIds } }, { session }).toArray();
   }
 
   getLessonsMetadataByRoomId(roomId, { session } = {}) {
     return this.collection.find({ roomId }, { projection: lessonMetadataProjection, session }).toArray();
+  }
+
+  getLessonsMetadataByCreatedBy(createdBy, { session } = {}) {
+    return this.collection.find({ createdBy }, { projection: lessonMetadataProjection, session }).toArray();
   }
 
   async saveLesson(lesson, { session } = {}) {

--- a/src/stores/lesson-store.js
+++ b/src/stores/lesson-store.js
@@ -36,7 +36,7 @@ class LessonStore {
     return this.collection.find({ roomId }, { projection: lessonMetadataProjection, session }).toArray();
   }
 
-  getLessonsMetadataByCreatedBy(createdBy, { session } = {}) {
+  getLessonsMetadataCreatedByUser(createdBy, { session } = {}) {
     return this.collection.find({ createdBy }, { projection: lessonMetadataProjection, session }).toArray();
   }
 

--- a/src/stores/lesson-store.js
+++ b/src/stores/lesson-store.js
@@ -36,8 +36,9 @@ class LessonStore {
     return this.collection.find({ roomId }, { projection: lessonMetadataProjection, session }).toArray();
   }
 
-  getLessonsMetadataCreatedByUser(createdBy, { session } = {}) {
-    return this.collection.find({ createdBy }, { projection: lessonMetadataProjection, session }).toArray();
+  getLatestLessonsMetadataCreatedByUser(createdBy, { session, limit } = {}) {
+    return this.collection.find({ createdBy }, { projection: lessonMetadataProjection, session })
+      .sort({ updatedOn: -1 }).limit(limit || 0).toArray();
   }
 
   async saveLesson(lesson, { session } = {}) {

--- a/src/stores/room-store.js
+++ b/src/stores/room-store.js
@@ -40,16 +40,16 @@ class RoomStore {
     return this.collection.find({ $or: [{ owner: userId }, { 'members.userId': userId }] }, { session }).toArray();
   }
 
-  getRoomsCreatedByUser(userId, { session } = {}) {
-    return this.collection.find({ createdBy: userId }, { session }).toArray();
+  getLatestRoomsCreatedByUser(userId, { session, limit } = {}) {
+    return this.collection.find({ createdBy: userId }, { session }).sort({ createdOn: -1 }).limit(limit || 0).toArray();
   }
 
-  getRoomsUpdatedByUser(userId, { session } = {}) {
-    return this.collection.find({ updatedBy: userId }, { session }).toArray();
+  getLatestRoomsUpdatedByUser(userId, { session, limit } = {}) {
+    return this.collection.find({ updatedBy: userId }, { session }).sort({ updatedOn: -1 }).limit(limit || 0).toArray();
   }
 
-  getRoomsJoinedByUser(userId, { session } = {}) {
-    return this.collection.find({ 'members.userId': userId }, { session }).toArray();
+  getLatestRoomsJoinedByUser(userId, { session, limit } = {}) {
+    return this.collection.find({ 'members.userId': userId }, { session }).sort({ 'members.joinedOn': -1 }).limit(limit || 0).toArray();
   }
 
   appendRoomMember({ roomId, member }, { session } = {}) {

--- a/src/stores/room-store.js
+++ b/src/stores/room-store.js
@@ -40,6 +40,18 @@ class RoomStore {
     return this.collection.find({ $or: [{ owner: userId }, { 'members.userId': userId }] }, { session }).toArray();
   }
 
+  getRoomsCreatedByUser(userId, { session } = {}) {
+    return this.collection.find({ createdBy: userId }, { session }).toArray();
+  }
+
+  getRoomsUpdatedByUser(userId, { session } = {}) {
+    return this.collection.find({ updatedBy: userId }, { session }).toArray();
+  }
+
+  getRoomsJoinedByUser(userId, { session } = {}) {
+    return this.collection.find({ 'members.userId': userId }, { session }).toArray();
+  }
+
   appendRoomMember({ roomId, member }, { session } = {}) {
     return this.collection.updateOne({ _id: roomId }, { $push: { members: member } }, { session });
   }

--- a/src/styles/antd-variable-overrides.less
+++ b/src/styles/antd-variable-overrides.less
@@ -735,7 +735,7 @@
 // @tabs-title-font-size: @font-size-base;
 // @tabs-title-font-size-lg: @font-size-lg;
 // @tabs-title-font-size-sm: @font-size-base;
-// @tabs-ink-bar-color: @primary-color;
+@tabs-ink-bar-color: @edu-tabs-ink-bar-color;
 // @tabs-bar-margin: 0 0 @margin-md 0;
 // @tabs-horizontal-gutter: 32px;
 // @tabs-horizontal-margin: 0 0 0 @tabs-horizontal-gutter;
@@ -746,8 +746,8 @@
 // @tabs-vertical-padding: @padding-xs @padding-lg;
 // @tabs-vertical-margin: @margin-md 0 0 0;
 // @tabs-scrolling-size: 32px;
-// @tabs-highlight-color: @primary-color;
-// @tabs-hover-color: @primary-5;
+@tabs-highlight-color: @edu-tabs-highlight-color;
+@tabs-hover-color: @edu-tabs-hover-color;
 // @tabs-active-color: @primary-7;
 // @tabs-card-gutter: 2px;
 // @tabs-card-tab-active-border-top: 2px solid transparent;

--- a/src/styles/global-variables.less
+++ b/src/styles/global-variables.less
@@ -70,6 +70,9 @@
 @edu-table-selected-row-bg: @edu-text-color;
 @edu-table-footer-color: @edu-text-color;
 @edu-card-head-color: @edu-content-title-color;
+@edu-tabs-ink-bar-color: @edu-text-color;
+@edu-tabs-highlight-color: @edu-text-color;
+@edu-tabs-hover-color: @edu-text-color;
 @edu-alert-message-color: @edu-text-color;
 @edu-info-color: @edu-primary-color-light;
 @edu-processing-color: @edu-primary-color-light;

--- a/src/styles/main.less
+++ b/src/styles/main.less
@@ -76,6 +76,7 @@
 @import '../components/favorite-star.less';
 @import '../components/tag-selector.less';
 @import '../components/sorting-selector.less';
+@import '../components/news-tab.less';
 
 // Pure CSS components
 @import '../styles/tag.less';

--- a/src/styles/tabs.less
+++ b/src/styles/tabs.less
@@ -1,7 +1,7 @@
 .Tabs {
-  padding-top: 20px;
+  padding-top: 50px;
 }
 
 .Tabs-tabPane {
-  padding-top: 50px;
+  padding: 40px 20px 0 20px;
 }

--- a/src/test-helper.js
+++ b/src/test-helper.js
@@ -156,6 +156,24 @@ export async function createTestRoom(container, roomValues) {
   return room;
 }
 
+export async function createTestLesson(container, lessonValues) {
+  const db = container.get(Database);
+  const now = new Date();
+
+  const lesson = {
+    _id: lessonValues._id || uniqueId.create(),
+    roomId: lessonValues.roomId || uniqueId.create(),
+    title: lessonValues.title || 'my-lesson',
+    slug: lessonValues.slug || 'my-lesson-slug',
+    schedule: lessonValues.slug || null,
+    createdBy: lessonValues.createdBy || uniqueId.create(),
+    createdOn: lessonValues.createdOn || now,
+    updatedOn: lessonValues.updatedOn || now
+  };
+  await db.lessons.insertOne(lesson);
+  return lesson;
+}
+
 export function createTestDocument(container, user, data) {
   const documentService = container.get(DocumentService);
   return documentService.createDocument({

--- a/src/ui/default-prop-types.js
+++ b/src/ui/default-prop-types.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import { PAGE_NAME } from '../domain/page-name.js';
-import { BATCH_TYPE, DOCUMENT_IMPORT_TYPE, ROOM_ACCESS_LEVEL, TASK_TYPE } from '../domain/constants.js';
+import { BATCH_TYPE, DOCUMENT_IMPORT_TYPE, ROOM_ACCESS_LEVEL, TASK_TYPE, USER_ACTIVITY_TYPE } from '../domain/constants.js';
 
 export const filePickerStorageShape = PropTypes.shape({
   rootPath: PropTypes.string.isRequired,
@@ -305,4 +305,14 @@ export const lessonMetadataShape = PropTypes.shape({
 
 export const lessonShape = PropTypes.shape({
   ...lessonMetadataProps
+});
+
+export const userActivitiesShape = PropTypes.shape({
+  type: PropTypes.oneOf(Object.values(USER_ACTIVITY_TYPE)).isRequired,
+  timestamp: PropTypes.string.isRequired,
+  data: PropTypes.shape({
+    _id: PropTypes.string,
+    title: PropTypes.string,
+    name: PropTypes.string
+  }).isRequired
 });


### PR DESCRIPTION
Closes https://educandu.atlassian.net/browse/EDU-427

and looks as follows:

<img width="1229" alt="Screen Shot 2022-03-10 at 11 40 23" src="https://user-images.githubusercontent.com/8189923/157645084-09105171-23e1-4826-8089-85d6ff4ab835.png">

<img width="496" alt="Screen Shot 2022-03-10 at 11 40 41" src="https://user-images.githubusercontent.com/8189923/157645096-17b0753c-2233-4f5a-b643-5363c54e03e2.png">
