### PR TITLE
EDU-528 Replace clipboard icon

### DIFF
--- a/src/components/icons/general/copy-to-clipboard-icon.js
+++ b/src/components/icons/general/copy-to-clipboard-icon.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import iconNs from '@ant-design/icons';
+
+const Icon = iconNs.default || iconNs;
+
+export function CopyToClipboardIconComponent() {
+  return (
+    <svg height="1em" style={{ enableBackground: 'new 0 0 1000 1000' }} width="1em" viewBox="0 0 1000 1000">
+      <path style={{ fill: 'none', stroke: 'currentColor', strokeWidth: '40', strokeLinecap: 'round', strokeLinejoin: 'round', strokeMiterlimit: '10' }} d="M365.4 783.03v-60.27m467.98-552.41h61.83c36.49 0 66.07 29.58 66.07 66.07v651.55c0 36.49-29.58 66.07-66.07 66.07H431.47c-36.49 0-66.07-29.58-66.07-66.07v0-104.94m0-428.65v58.809V236.41c0-36.49 29.58-66.07 66.07-66.07h63.09" transform="translate(-90)" />
+      <path style={{ fill: 'none', stroke: 'currentColor', strokeWidth: '40', strokeLinecap: 'round', strokeLinejoin: 'round', strokeMiterlimit: '10' }} d="M801.21 221.23H469.47c-1.2 0-2.17-.97-2.17-2.17V118.12c0-1.2.97-2.17 2.17-2.17h331.74c1.2 0 2.17.97 2.17 2.17v100.95c0 1.19-.97 2.16-2.17 2.16zm-42.99-105.28V71.39c0-14.04-11.38-25.42-25.42-25.42H537.88c-14.04 0-25.42 11.38-25.42 25.42v44.56z" transform="translate(-62)" />
+      <path style={{ fill: 'none', stroke: 'currentColor', strokeWidth: '40', strokeLinecap: 'round', strokeLinejoin: 'round', strokeMiterlimit: '10' }} d="M-48.339 563.96H397.99" transform="translate(148 -2)" />
+      <path style={{ fill: 'none', stroke: 'currentColor', strokeWidth: '40', strokeLinecap: 'round', strokeLinejoin: 'round', strokeMiterlimit: '10' }} d="m263.87 706.34 166.78-144.38-166.78-144.37" transform="matrix(1.005 0 0 .954 164.265 24.904)" />
+      <path style={{ fill: 'none', stroke: 'currentColor', strokeWidth: '40', strokeLinecap: 'round', strokeLinejoin: 'round', strokeMiterlimit: '10' }} d="M863.06 755.7v91.98c0 17.53-14.21 31.75-31.75 31.75H723.19" transform="translate(-62)" />
+    </svg>
+  );
+}
+
+function CopyToClipboardIcon() {
+  return (
+    <Icon component={CopyToClipboardIconComponent} />
+  );
+}
+
+export default CopyToClipboardIcon;

--- a/src/components/icons/general/paste-from-clipboard-icon.js
+++ b/src/components/icons/general/paste-from-clipboard-icon.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import iconNs from '@ant-design/icons';
+
+const Icon = iconNs.default || iconNs;
+
+export function PasteFromClipboardIconComponent() {
+  return (
+    <svg height="1em" style={{ enableBackground: 'new 0 0 1000 1000' }} width="1em" viewBox="0 0 1000 1000">
+      <path style={{ fill: 'none', stroke: 'currentColor', strokeWidth: '40', strokeLinecap: 'round', strokeLinejoin: 'round', strokeMiterlimit: '10' }} d="M425.222 552.432h473.649" transform="translate(8 -4)" />
+      <path style={{ fill: 'none', stroke: 'currentColor', strokeWidth: '40', strokeLinecap: 'round', strokeLinejoin: 'round', strokeMiterlimit: '10' }} d="m263.87 706.34 166.78-144.38-166.78-144.37" transform="matrix(1.005 0 0 .954 525.722 17.057)" />
+      <path style={{ fill: 'none', stroke: 'currentColor', strokeWidth: '40', strokeLinecap: 'round', strokeLinejoin: 'round', strokeMiterlimit: '10' }} d="M676.59 783.03v-60.27M208.61 170.35h-61.83c-36.49 0-66.07 29.58-66.07 66.07v651.55c0 36.49 29.58 66.07 66.07 66.07h463.74c36.49 0 66.07-29.58 66.07-66.07V783.03m-1.597-406.297v0l1.597-109.113v-31.21c0-36.49-29.58-66.07-66.07-66.07h-50.351" transform="translate(-4)" />
+      <path style={{ fill: 'none', stroke: 'currentColor', strokeWidth: '40', strokeLinecap: 'round', strokeLinejoin: 'round', strokeMiterlimit: '10' }} d="M212.78 221.23h331.74c1.2 0 2.17-.97 2.17-2.17V118.12c0-1.2-.97-2.17-2.17-2.17H212.78c-1.2 0-2.17.97-2.17 2.17v100.95c0 1.19.97 2.16 2.17 2.16zm42.99-105.28V71.39c0-14.04 11.38-25.42 25.42-25.42h194.92c14.04 0 25.42 11.38 25.42 25.42v44.56H255.77zM146.92 755.7v91.98c0 17.53 14.21 31.75 31.75 31.75H286.8" />
+    </svg>
+  );
+}
+
+function PasteFromClipboardIcon() {
+  return (
+    <Icon component={PasteFromClipboardIconComponent} />
+  );
+}
+
+export default PasteFromClipboardIcon;

--- a/src/components/plugin-selector-dialog.js
+++ b/src/components/plugin-selector-dialog.js
@@ -4,8 +4,9 @@ import GridSelector from './grid-selector.js';
 import { useTranslation } from 'react-i18next';
 import React, { useMemo, useState } from 'react';
 import { useService } from './container-context.js';
+import { QuestionOutlined } from '@ant-design/icons';
 import PluginRegistry from '../plugins/plugin-registry.js';
-import { PaperClipOutlined, QuestionOutlined } from '@ant-design/icons';
+import PasteFromClipboardIcon from './icons/general/paste-from-clipboard-icon.js';
 
 function PluginSelectorDialog({ visible, onSelect, onCancel, onPasteFromClipboard }) {
   const { t } = useTranslation('pluginSelectorDialog');
@@ -37,7 +38,7 @@ function PluginSelectorDialog({ visible, onSelect, onCancel, onPasteFromClipboar
     <div className="PluginSelectorDialog-footer">
       <div>
         <Button
-          icon={<PaperClipOutlined />}
+          icon={<PasteFromClipboardIcon />}
           onClick={onPasteFromClipboard}
           className="PluginSelectorDialog-pasteButton"
           >

--- a/src/components/section-display.js
+++ b/src/components/section-display.js
@@ -15,8 +15,9 @@ import MoveDownIcon from './icons/general/move-down-icon.js';
 import NotSupportedSection from './not-supported-section.js';
 import DuplicateIcon from './icons/general/duplicate-icon.js';
 import HardDeleteIcon from './icons/general/hard-delete-icon.js';
+import CopyToClipboardIcon from './icons/general/copy-to-clipboard-icon.js';
+import { CheckOutlined, CloseOutlined, DragOutlined } from '@ant-design/icons';
 import { sectionShape, filePickerStorageShape } from '../ui/default-prop-types.js';
-import { CheckOutlined, CloseOutlined, DragOutlined, PaperClipOutlined } from '@ant-design/icons';
 
 function SectionDisplay({
   section,
@@ -100,7 +101,7 @@ function SectionDisplay({
     {
       type: 'copyToClipboard',
       tooltip: renderActionTooltip('copyToClipboard'),
-      icon: <PaperClipOutlined key="copyToClipboard" />,
+      icon: <CopyToClipboardIcon key="copyToClipboard" />,
       handleAction: () => onSectionCopyToClipboard(),
       isVisible: true,
       isEnabled: !!section.content


### PR DESCRIPTION
Closes https://educandu.atlassian.net/browse/EDU-528

Original icons:
<img width="161" alt="Screen Shot 2022-05-03 at 10 08 34" src="https://user-images.githubusercontent.com/8189923/166422228-5787a61a-e7f6-4a73-b886-bc08083b7491.png">

<img width="508" alt="Screen Shot 2022-05-03 at 10 10 56" src="https://user-images.githubusercontent.com/8189923/166422232-7ebdbe81-5184-4ca7-ac85-a0889e81fa4e.png">

Adjusted icons:
<img width="181" alt="Screen Shot 2022-05-03 at 10 03 24" src="https://user-images.githubusercontent.com/8189923/166421562-c1058ba0-30e6-4ec7-acac-06de59817025.png">

<img width="514" alt="Screen Shot 2022-05-03 at 10 03 38" src="https://user-images.githubusercontent.com/8189923/166421565-a002e434-953e-4dcf-9863-0d0a1ee65b33.png">
