### PR TITLE
EDU-563 Keep image tile link style as set globally (do not overwrite)

### DIFF
--- a/src/plugins/image-tiles/image-tiles-display.js
+++ b/src/plugins/image-tiles/image-tiles-display.js
@@ -39,14 +39,14 @@ function ImageTilesDisplay({ content }) {
     const imageUrl = getTileImageUrl(tile, clientConfig.cdnRootUrl);
 
     const classes = classNames({
-      'ImageTiles-tile': true,
-      'ImageTiles-tile--noLink': !linkUrl,
+      'ImageTilesDisplay-tile': true,
+      'ImageTilesDisplay-tile--noLink': !linkUrl,
       'u-img-color-flip': content.hoverEffect === HOVER_EFFECT.colorizeZoom && linkUrl,
       'u-img-color-flip-hover-disabled': content.hoverEffect === HOVER_EFFECT.colorizeZoom && !linkUrl
     });
 
-    const image = <img className="ImageTiles-img" src={imageUrl} />;
-    const description = <div className="ImageTiles-description"><Markdown>{tile.description}</Markdown></div>;
+    const image = <img className="ImageTilesDisplay-img" src={imageUrl} />;
+    const description = <div className="ImageTilesDisplay-description"><Markdown>{tile.description}</Markdown></div>;
 
     return linkUrl
       ? <a key={index.toString()} className={classes} href={linkUrl}>{image}{description}</a>
@@ -54,9 +54,9 @@ function ImageTilesDisplay({ content }) {
   };
 
   return (
-    <div className={classNames('ImageTiles')}>
+    <div className="ImageTilesDisplay">
       <div
-        className={`ImageTiles-grid u-max-width-${content.maxWidth || 100}`}
+        className={`ImageTilesDisplay-grid u-max-width-${content.maxWidth || 100}`}
         style={{ gridTemplateColumns: `repeat(${content.maxTilesPerRow}, 1fr)` }}
         >
         {content.tiles.map(renderTile)}

--- a/src/plugins/image-tiles/image-tiles.less
+++ b/src/plugins/image-tiles/image-tiles.less
@@ -1,6 +1,6 @@
-.ImageTiles {}
+.ImageTilesDisplay {}
 
-.ImageTiles-grid {
+.ImageTilesDisplay-grid {
   display: grid;
   align-items: start;
   gap: 20px;
@@ -8,19 +8,19 @@
   margin-right: auto;
 }
 
-.ImageTiles-tile {
+.ImageTilesDisplay-tile {
   text-align: center;
   overflow-x: hidden;
 
-  &.ImageTiles-tile--noLink {
+  &.ImageTilesDisplay-tile--noLink {
     cursor: not-allowed;
   }
 }
 
-.ImageTiles-img {
+.ImageTilesDisplay-img {
   max-width: 100%;
 }
 
-.ImageTiles-description {
-  color: @edu-text-color;
+.ImageTilesDisplay-description {
+  color: inherit;
 }


### PR DESCRIPTION
Closes https://educandu.atlassian.net/browse/EDU-563

On ELMU it the following tiles case:
- first tile has an internal document as the link and markdown formatting as the description
- second tile has no link
- third tile has en external link as the link
would be fixed and look like:
<img width="835" alt="Screen Shot 2022-05-19 at 17 31 34" src="https://user-images.githubusercontent.com/8189923/169337483-4a307c9e-9f2b-4c2f-8fca-42d216654631.png">
