### PR TITLE
EDU-618 Rework lessons list styling to be responsive for all view cases

### DIFF
--- a/src/components/pages/room.js
+++ b/src/components/pages/room.js
@@ -180,17 +180,19 @@ export default function Room({ PageTemplate, initialState }) {
     return (
       <div className="RoomPage-lesson" key={lesson._id}>
         <div className={`RoomPage-lessonInfo ${isUpcomingLesson ? 'is-highlighted' : ''}`}>
-          {(isRoomOwner || isRoomCollaborator) && (
+          <div className="RoomPage-lessonInfoGroup">
+            {(isRoomOwner || isRoomCollaborator) && (
             <Fragment>
               <Tooltip title={t('common:clone')}>
-                <Button size="small" type="link" icon={<DuplicateIcon />} onClick={() => handleNewLessonClick(lesson)} />
+                <Button className="RoomPage-lessonButton" size="small" type="link" icon={<DuplicateIcon />} onClick={() => handleNewLessonClick(lesson)} />
               </Tooltip>
               <Tooltip title={t('common:delete')}>
-                <DeleteButton className="RoomPage-deleteButton" onClick={() => handleDeleteLessonClick(lesson)} />
+                <DeleteButton className="RoomPage-lessonButton" onClick={() => handleDeleteLessonClick(lesson)} />
               </Tooltip>
             </Fragment>
-          )}
-          <span>{startsOn ? formatDate(startsOn) : t('notScheduled')}</span>
+            )}
+            <span className="RoomPage-lessonDate">{startsOn ? formatDate(startsOn) : t('notScheduled')}</span>
+          </div>
           <a className="RoomPage-lessonTitle" href={url}>{lesson.title}</a>
           <span className="RoomPage-lessonTimeUntil">{timeUntil}</span>
         </div>
@@ -229,7 +231,7 @@ export default function Room({ PageTemplate, initialState }) {
           type="primary"
           shape="circle"
           icon={<PlusOutlined />}
-          size="large"
+          size="medium"
           onClick={handleCreateInvitationButtonClick}
           />
       ]}
@@ -267,7 +269,7 @@ export default function Room({ PageTemplate, initialState }) {
           type="primary"
           shape="circle"
           icon={<PlusOutlined />}
-          size="large"
+          size="medium"
           onClick={() => handleNewLessonClick()}
           />
       ]}

--- a/src/components/pages/room.less
+++ b/src/components/pages/room.less
@@ -16,9 +16,9 @@
 }
 
 .RoomPage-lessonInfo {
-  display: grid;
+  display: flex;
+  flex-wrap: wrap;
   padding: 10px;
-  grid-template-columns: 30px 30px @room-date-label-width auto auto;
 
   &.is-highlighted {
     border: 1px solid fade(@edu-primary-color-light, 10%);
@@ -26,30 +26,32 @@
     border-left: none;
     border-right: none;
   }
+}
 
-  @media @edu-media-phone {
+.RoomPage-lessonInfoGroup {
+  display: flex;
+  gap: @edu-content-padding;
+  padding-right: @edu-content-padding;
+}
 
-    & .RoomPage-lessonTitle,
-    & .RoomPage-lessonTimeUntil {
-      grid-column-start: 1;
-      grid-column-end: 6;
-    }
-  }
+.RoomPage-lessonDate {
+  width: @room-date-label-width;
 }
 
 .RoomPage-lessonTitle {
-  padding-left: 5px;
+  @media @edu-media-phone {
+    flex: 1 0 100%;
+  }
 }
 
-.RoomPage-deleteButton {
-  margin-right: @edu-content-padding;
+.RoomPage-lessonButton {
+  flex: 0 0 0%;
 }
 
 .RoomPage-lessonTimeUntil {
   font-size: 13px;
   margin-left: auto;
   margin-right: 0;
-  padding-left: 15px;
 }
 
 .RoomPage-newLessonButton {


### PR DESCRIPTION
Closes https://educandu.atlassian.net/browse/EDU-618

**Owner/collaborator views on desktop and mobile:**
<img width="893" alt="Screen Shot 2022-06-24 at 10 30 49" src="https://user-images.githubusercontent.com/8189923/175497033-1ebb616f-949c-41b5-83f3-22426be63923.png">
<img width="476" alt="Screen Shot 2022-06-24 at 10 30 40" src="https://user-images.githubusercontent.com/8189923/175497027-b4162eaf-67ce-4d3a-8a23-9dc8a94ea29f.png">

**Member (non-collaborator) views on desktop and mobile:**
<img width="932" alt="Screen Shot 2022-06-24 at 10 31 10" src="https://user-images.githubusercontent.com/8189923/175497204-9922a723-7390-4609-94c7-440a1e9b88e4.png">
<img width="519" alt="Screen Shot 2022-06-24 at 10 30 17" src="https://user-images.githubusercontent.com/8189923/175497198-a4ade17f-193a-493a-b823-854ad959a3ff.png">
