### PR TITLE
EDU-756 adjust search relevance logic

### DIFF
--- a/src/components/pages/search.js
+++ b/src/components/pages/search.js
@@ -44,7 +44,7 @@ function Search({ PageTemplate }) {
   ];
 
   const sorters = useMemo(() => ({
-    relevance: rowsToSort => rowsToSort.sort(by(row => row.document.tagMatchCount, sorting.direction).thenBy(row => row.document.updatedOn, 'desc')),
+    relevance: rowsToSort => rowsToSort.sort(by(row => row.document.relevance, sorting.direction).thenBy(row => row.document.updatedOn, 'desc')),
     title: rowsToSort => rowsToSort.sort(by(row => row.document.title, { direction: sorting.direction, ignoreCase: true })),
     createdOn: rowsToSort => rowsToSort.sort(by(row => row.document.createdOn, sorting.direction)),
     updatedOn: rowsToSort => rowsToSort.sort(by(row => row.document.updatedOn, sorting.direction)),

--- a/src/domain/constants.js
+++ b/src/domain/constants.js
@@ -156,6 +156,8 @@ export const DOCUMENT_ALLOWED_OPEN_CONTRIBUTION = {
   none: 'none'
 };
 
+export const DOCUMENT_VERIFIED_RELEVANCE_POINTS = 3;
+
 export const CDN_URL_PREFIX = 'cdn://';
 
 export const AVATAR_SIZE = 110;

--- a/src/services/document-service.spec.js
+++ b/src/services/document-service.spec.js
@@ -1099,6 +1099,7 @@ describe('document-service', () => {
         slug: 'doc-1',
         sections: [],
         tags: ['music', 'instructor', 'Dj.D', 'Cretu'],
+        verified: false,
         archived: false,
         language: 'en'
       });
@@ -1109,6 +1110,7 @@ describe('document-service', () => {
         slug: 'doc-2',
         sections: [],
         tags: ['Music', 'Instructor', 'Goga'],
+        verified: false,
         archived: false,
         language: 'en'
       });
@@ -1119,6 +1121,7 @@ describe('document-service', () => {
         slug: 'doc-3',
         sections: [],
         tags: ['Wolf', 'gang', 'from', 'Beat', 'oven', 'music'],
+        verified: true,
         archived: false,
         language: 'en'
       });
@@ -1129,6 +1132,7 @@ describe('document-service', () => {
         slug: 'doc-4',
         sections: [],
         tags: ['Wolf', 'gang', 'from', 'Beat', 'oven', 'music'],
+        verified: false,
         archived: true,
         language: 'en'
       });
@@ -1141,6 +1145,7 @@ describe('document-service', () => {
         slug: 'doc-5',
         sections: [],
         tags: ['Wolf', 'gang', 'from', 'Beat', 'oven', 'music'],
+        verified: false,
         archived: false,
         language: 'en'
       });
@@ -1186,7 +1191,7 @@ describe('document-service', () => {
         expect(result.slug).toEqual(doc3.slug);
         expect(result.tags).toEqual(doc3.tags);
         expect(result.language).toEqual(doc3.language);
-        expect(result.tagMatchCount).toEqual(4);
+        expect(result.relevance).toEqual(7);
         expect(result.updatedOn).not.toBeNull();
         expect(result.sections).toBeUndefined();
       });
@@ -1198,7 +1203,7 @@ describe('document-service', () => {
         expect(results.map(result => result.title)).not.toContain('Doc 4');
       });
 
-      it('contains all documents with the correct tag match count', async () => {
+      it('contains all documents with the correct relevance', async () => {
         const results = await sut.getSearchableDocumentsMetadataByTags('music instructor goga');
 
         expect(results).toHaveLength(3);
@@ -1208,9 +1213,9 @@ describe('document-service', () => {
           return acc;
         }, {});
 
-        expect(resultMap[doc1.title].tagMatchCount).toEqual(2);
-        expect(resultMap[doc2.title].tagMatchCount).toEqual(3);
-        expect(resultMap[doc3.title].tagMatchCount).toEqual(1);
+        expect(resultMap[doc1.title].relevance).toEqual(2);
+        expect(resultMap[doc2.title].relevance).toEqual(3);
+        expect(resultMap[doc3.title].relevance).toEqual(4);
       });
     });
 

--- a/src/stores/document-store.js
+++ b/src/stores/document-store.js
@@ -27,6 +27,7 @@ const documentExtendedMetadataProjection = {
   updatedBy: 1,
   tags: 1,
   review: 1,
+  verified: 1,
   archived: 1,
   origin: 1,
   originUrl: 1,


### PR DESCRIPTION
https://educandu.atlassian.net/browse/EDU-756

This is a very naïve implementation making verified documents simply counting "3 matched tags more". For more sophisticated system we would have to also change the way we make tags count and open a bigger box. So maybe we can try and see how far we can get with this solution?