### PR TITLE
EDU-788 Clip text in track mixer bars to bar size

### DIFF
--- a/src/components/media-player/track-mixer.less
+++ b/src/components/media-player/track-mixer.less
@@ -51,6 +51,7 @@
   display: flex;
   align-items: center;
   justify-content: flex-end;
+  overflow-x: hidden;
   padding: 0 4px;
 
   &.TrackMixer-bar--secondaryTrack {


### PR DESCRIPTION
Closes https://educandu.atlassian.net/browse/EDU-788

...and looks like this (text intentionally made black):
![localhost_3000_tests_tab=MultitrackMediaPlugin](https://user-images.githubusercontent.com/2676617/189131818-d2a27232-ab97-4ec6-866d-4b9c6049b9f7.png)
