### PR TITLE
EDU-832 Extend export import functionality

### DIFF
--- a/src/api-clients/export-api-client.js
+++ b/src/api-clients/export-api-client.js
@@ -25,14 +25,14 @@ class ExportApiClient {
       .then(res => res.data);
   }
 
-  async getDocumentExport({ baseUrl, apiKey, documentId, toRevision }) {
+  async getDocumentExport({ baseUrl, apiKey, documentId, toRevision, includeEmails }) {
     const databaseSchemaHash = await this.database.getSchemaHash();
 
     return this.httpClient
       .get(
         `${baseUrl}/api/v1/exports/${encodeURIComponent(documentId)}`,
         {
-          params: { toRevision, databaseSchemaHash },
+          params: { toRevision, includeEmails, databaseSchemaHash },
           headers: { [API_KEY_HEADER]: apiKey },
           responseType: 'json'
         }

--- a/src/api-clients/import-api-client.js
+++ b/src/api-clients/import-api-client.js
@@ -19,11 +19,11 @@ class ImportApiClient {
       .then(res => res.data);
   }
 
-  postImport({ hostName, documentsToImport }) {
+  postImport({ hostName, documentsToImport, nativeImport }) {
     return this.httpClient
       .post(
         '/api/v1/imports',
-        { hostName, documentsToImport },
+        { hostName, documentsToImport, nativeImport },
         { responseType: 'json' }
       )
       .then(res => res.data);

--- a/src/components/pages/create-import.less
+++ b/src/components/pages/create-import.less
@@ -4,6 +4,13 @@
   min-width: 280px;
 }
 
+.CreateImportPage-input {
+  width: 300px;
+  display: block;
+  margin-left: auto;
+  margin-top: (@edu-content-padding * 2);
+}
+
 .CreateImportPage-importButton {
-  margin: (@edu-content-padding * 2) 0;
+  margin: 5px 0 (@edu-content-padding * 2) 0;
 }

--- a/src/components/pages/create-import.yml
+++ b/src/components/pages/create-import.yml
@@ -4,3 +4,6 @@ importButton:
 backToImports:
   en: Back to the overview
   de: Zurück zur Übersicht
+nativeImportPlaceholder:
+  en: Text for native import
+  de: Text für Schlussimport

--- a/src/domain/schemas/export-schemas.js
+++ b/src/domain/schemas/export-schemas.js
@@ -1,11 +1,12 @@
 import joi from 'joi';
-import { idOrKeySchema } from './shared-schemas.js';
+import { boolStringSchema, idOrKeySchema } from './shared-schemas.js';
 
 export const getExportsQuerySchema = joi.object({
   databaseSchemaHash: joi.string().required()
 });
 
 export const getExportsDocumentQuerySchema = joi.object({
+  includeEmails: boolStringSchema,
   toRevision: idOrKeySchema.required(),
   databaseSchemaHash: joi.string().required()
 });

--- a/src/domain/schemas/import-schemas.js
+++ b/src/domain/schemas/import-schemas.js
@@ -1,6 +1,6 @@
 import joi from 'joi';
-import { idOrKeySchema } from './shared-schemas.js';
 import { DOCUMENT_IMPORT_TYPE } from '../../domain/constants.js';
+import { boolStringSchema, idOrKeySchema } from './shared-schemas.js';
 
 const importedDocumentSchema = joi.object({
   _id: idOrKeySchema.required(),
@@ -23,5 +23,6 @@ export const createImportQuerySchema = joi.object({
 
 export const postImportBodySchema = joi.object({
   hostName: joi.string().required(),
-  documentsToImport: joi.array().required().items(importedDocumentSchema)
+  documentsToImport: joi.array().required().items(importedDocumentSchema),
+  nativeImport: boolStringSchema
 });

--- a/src/resources/resources.json
+++ b/src/resources/resources.json
@@ -954,7 +954,8 @@
     "language": "en",
     "resources": {
       "importButton": "Start import",
-      "backToImports": "Back to the overview"
+      "backToImports": "Back to the overview",
+      "nativeImportPlaceholder": "Text for native import"
     }
   },
   {
@@ -962,7 +963,8 @@
     "language": "de",
     "resources": {
       "importButton": "Import starten",
-      "backToImports": "Zurück zur Übersicht"
+      "backToImports": "Zurück zur Übersicht",
+      "nativeImportPlaceholder": "Text für Schlussimport"
     }
   },
   {

--- a/src/server/export-controller.js
+++ b/src/server/export-controller.js
@@ -33,6 +33,8 @@ class ExportController {
   async handleGetExport(req, res) {
     const documentId = req.params.documentId;
     const toRevision = req.query.toRevision;
+    const includeEmails = req.query.includeEmails === true.toString();
+
     const importingSystemSchemaHash = req.query.databaseSchemaHash;
 
     const schemaHash = await this.database.getSchemaHash();
@@ -40,7 +42,7 @@ class ExportController {
       throw new BadRequest(`Database schema mismatch between importing system (${importingSystemSchemaHash}) and exporting system (${schemaHash})`);
     }
 
-    const { revisions, users, cdnRootUrl } = await this.exportService.getDocumentExport({ documentId, toRevision });
+    const { revisions, users, cdnRootUrl } = await this.exportService.getDocumentExport({ documentId, toRevision, includeEmails });
 
     return res.send({ revisions, users, cdnRootUrl });
   }

--- a/src/server/import-controller.js
+++ b/src/server/import-controller.js
@@ -57,7 +57,7 @@ class ImportController {
   }
 
   async handlePostImport(req, res) {
-    const { hostName, documentsToImport } = req.body;
+    const { hostName, documentsToImport, nativeImport } = req.body;
     const user = req.user;
 
     const importSource = this.serverConfig.importSources.find(source => source.hostName === hostName);
@@ -65,7 +65,7 @@ class ImportController {
       throw new NotFound(`'${hostName}' is not a host name of a known import source`);
     }
 
-    const batch = await this.batchService.createImportBatch({ importSource, documentsToImport, user });
+    const batch = await this.batchService.createImportBatch({ importSource, documentsToImport, user, nativeImport });
     res.status(201).send({ batch });
   }
 

--- a/src/services/batch-service.js
+++ b/src/services/batch-service.js
@@ -29,8 +29,8 @@ class BatchService {
     this.roomStore = roomStore;
   }
 
-  async createImportBatch({ importSource, documentsToImport, user }) {
-    const batchParams = { ...importSource };
+  async createImportBatch({ importSource, documentsToImport, user, nativeImport = false }) {
+    const batchParams = { ...importSource, nativeImport };
     delete batchParams.apiKey;
 
     const batch = this._createBatchObject(user._id, BATCH_TYPE.documentImport, batchParams);

--- a/src/services/batch-service.spec.js
+++ b/src/services/batch-service.spec.js
@@ -95,7 +95,8 @@ describe('batch-service', () => {
             batchParams: {
               name: 'source-1',
               hostName: 'source1.com',
-              allowUnsecure: false
+              allowUnsecure: false,
+              nativeImport: false
             },
             errors: []
           }
@@ -140,7 +141,32 @@ describe('batch-service', () => {
         const dbEntries = await db.batches.find({}).toArray();
         expect(dbEntries).toEqual([result]);
       });
+    });
 
+    describe('when creating a new batch with nativeImport', () => {
+      beforeEach(async () => {
+        await sut.createImportBatch({ importSource, documentsToImport, user, nativeImport: true });
+      });
+
+      it('creates a new batch in the database', async () => {
+        const dbEntries = await db.batches.find({}).toArray();
+        expect(dbEntries).toEqual([
+          {
+            _id: expect.stringMatching(/\w+/),
+            createdBy: user._id,
+            createdOn: expect.any(Date),
+            completedOn: null,
+            batchType: BATCH_TYPE.documentImport,
+            batchParams: {
+              name: 'source-1',
+              hostName: 'source1.com',
+              allowUnsecure: false,
+              nativeImport: true
+            },
+            errors: []
+          }
+        ]);
+      });
     });
 
     describe('when there is an existing lock for the same import source', () => {
@@ -345,7 +371,8 @@ describe('batch-service', () => {
           batchParams: {
             name: 'source-1',
             hostName: 'source1.com',
-            allowUnsecure: false
+            allowUnsecure: false,
+            nativeImport: false
           },
           errors: [],
           progress: 0.5
@@ -359,7 +386,8 @@ describe('batch-service', () => {
           batchParams: {
             name: 'source-1',
             hostName: 'source2',
-            allowUnsecure: false
+            allowUnsecure: false,
+            nativeImport: false
           },
           errors: [],
           progress: 0
@@ -426,7 +454,8 @@ describe('batch-service', () => {
         batchParams: {
           name: 'source-1',
           hostName: 'source1.com',
-          allowUnsecure: false
+          allowUnsecure: false,
+          nativeImport: false
         },
         errors: [],
         progress: 0.5,

--- a/src/services/document-import-task-processor.js
+++ b/src/services/document-import-task-processor.js
@@ -33,7 +33,7 @@ class DocumentImportTaskProcessor {
       apiKey: importSource.apiKey,
       documentId,
       toRevision: importableRevision,
-      includeEmails: batchParams.nativeImport || false
+      includeEmails: batchParams.nativeImport
     });
 
     if (ctx.cancellationRequested) {

--- a/src/services/document-import-task-processor.js
+++ b/src/services/document-import-task-processor.js
@@ -32,15 +32,34 @@ class DocumentImportTaskProcessor {
       baseUrl: routes.getImportSourceBaseUrl(importSource),
       apiKey: importSource.apiKey,
       documentId,
-      toRevision: importableRevision
+      toRevision: importableRevision,
+      includeEmails: batchParams.nativeImport || false
     });
 
     if (ctx.cancellationRequested) {
       throw new Error('Cancellation requested');
     }
 
-    await Promise.all(documentExport.users
-      .map(user => this.userService.ensureExternalUser({ _id: user._id, displayName: user.displayName, hostName: batchParams.hostName })));
+    if (batchParams.nativeImport) {
+      const userMap = {};
+      for (const user of documentExport.users) {
+        const userId = await this.userService.ensureInternalUser({ _id: user._id, displayName: user.displayName, email: user.email });
+        userMap[user._id] = userId;
+      }
+
+      documentExport.revisions.forEach(revision => {
+        revision.createdBy = userMap[revision.createdBy];
+        revision.sections.forEach(section => {
+          if (section.deletedBy) {
+            section.deletedBy = userMap[section.deletedBy];
+          }
+        });
+      });
+
+    } else {
+      await Promise.all(documentExport.users
+        .map(user => this.userService.ensureExternalUser({ _id: user._id, displayName: user.displayName, hostName: batchParams.hostName })));
+    }
 
     if (ctx.cancellationRequested) {
       throw new Error('Cancellation requested');
@@ -66,8 +85,8 @@ class DocumentImportTaskProcessor {
     const docUrl = routes.getDocUrl({ id: sortedRevisions[0].documentId, slug: sortedRevisions[0].slug });
     const baseUrl = routes.getImportSourceBaseUrl(importSource);
 
-    const originUrl = `${baseUrl}${docUrl}`;
-    const origin = `${DOCUMENT_ORIGIN.external}/${batchParams.hostName}`;
+    const originUrl = batchParams.nativeImport ? null : `${baseUrl}${docUrl}`;
+    const origin = batchParams.nativeImport ? DOCUMENT_ORIGIN.internal : `${DOCUMENT_ORIGIN.external}/${batchParams.hostName}`;
 
     await this.documentService.importDocumentRevisions({
       documentId,

--- a/src/services/export-service.js
+++ b/src/services/export-service.js
@@ -24,7 +24,7 @@ class ExportService {
       .sort(by(doc => doc.updatedOn, 'desc'));
   }
 
-  async getDocumentExport({ documentId, toRevision }) {
+  async getDocumentExport({ documentId, toRevision, includeEmails = false }) {
     const revisions = await this.documentRevisionStore.getAllDocumentRevisionsByDocumentId(documentId);
     const lastRevisionIndex = revisions.findIndex(revision => revision._id === toRevision);
 
@@ -36,7 +36,7 @@ class ExportService {
 
     const userIds = extractUserIdsFromDocsOrRevisions(revisionsToExport);
     const users = (await this.userStore.getUsersByIds(userIds))
-      .map(({ _id, displayName }) => ({ _id, displayName }));
+      .map(({ _id, displayName, email }) => ({ _id, displayName, email: includeEmails ? email : null }));
 
     if (users.length !== userIds.length) {
       throw new Error(`Was searching for ${users.length} users in document ${documentId} up to revision '${toRevision}', but found ${userIds.length}`);

--- a/src/services/export-service.spec.js
+++ b/src/services/export-service.spec.js
@@ -88,7 +88,7 @@ describe('export-service', () => {
     beforeEach(() => {
       sandbox.stub(documentRevisionStore, 'getAllDocumentRevisionsByDocumentId');
 
-      userStore.getUsersByIds.resolves([{ _id: 'user1', displayName: 'JohnDoe' }]);
+      userStore.getUsersByIds.resolves([{ _id: 'user1', displayName: 'JohnDoe', email: 'johndoe@test.com' }]);
       documentRevisionStore.getAllDocumentRevisionsByDocumentId.resolves([rev1, rev2, rev3]);
     });
 
@@ -130,7 +130,25 @@ describe('export-service', () => {
       });
 
       it('should return revisions', () => {
-        expect(result).toEqual({ revisions: [rev1, rev2], users: [{ _id: 'user1', displayName: 'JohnDoe' }], cdnRootUrl: 'https://cdn.root.url' });
+        expect(result).toEqual({
+          revisions: [rev1, rev2],
+          users: [{ _id: 'user1', displayName: 'JohnDoe', email: null }],
+          cdnRootUrl: 'https://cdn.root.url'
+        });
+      });
+    });
+
+    describe('with includeEmails = true', () => {
+      beforeEach(async () => {
+        result = await sut.getDocumentExport({ documentId: 'abc', toRevision: '2', includeEmails: true });
+      });
+
+      it('should return revisions', () => {
+        expect(result).toEqual({
+          revisions: [rev1, rev2],
+          users: [{ _id: 'user1', displayName: 'JohnDoe', email: 'johndoe@test.com' }],
+          cdnRootUrl: 'https://cdn.root.url'
+        });
       });
     });
   });

--- a/src/services/user-service.spec.js
+++ b/src/services/user-service.spec.js
@@ -350,4 +350,72 @@ describe('user-service', () => {
     });
   });
 
+  describe('ensureInternalUser', () => {
+    let result;
+
+    describe('when there is an internal active user with the same email', () => {
+      beforeEach(async () => {
+        result = await sut.ensureInternalUser({ _id: uniqueId.create(), displayName: 'John', email: user.email });
+        await setupTestUser(container, { email: 'user1@test.com', password, displayName: 'User 1', accountClosedOn: now });
+      });
+
+      it('should return the existing active user\'s id', () => {
+        expect(result).toEqual(user._id);
+      });
+    });
+
+    describe('when there are several internal closed account users with the same email', () => {
+      let usersWithClosedAccounts;
+
+      beforeEach(async () => {
+        usersWithClosedAccounts = [
+          await setupTestUser(container, { email: 'user1@test.com', password, displayName: 'User 1', accountClosedOn: now }),
+          await setupTestUser(container, { email: 'user2@test.com', password, displayName: 'User 2', accountClosedOn: now })
+        ];
+
+        result = await sut.ensureInternalUser({ _id: uniqueId.create(), displayName: 'John', email: 'user1@test.com' });
+      });
+
+      it('should return the id of the first matching user', () => {
+        expect(result).toEqual(usersWithClosedAccounts[0]._id);
+      });
+    });
+
+    describe('when there is no internal user with the same email', () => {
+      const newUserId = uniqueId.create();
+
+      beforeEach(async () => {
+        result = await sut.ensureInternalUser({ _id: newUserId, displayName: 'John', email: 'user1@test.com' });
+      });
+
+      it('should return the id of the created user', () => {
+        expect(result).toEqual(newUserId);
+      });
+
+      it('should create a closed account user', async () => {
+        const newUser = await db.users.findOne({ _id: newUserId });
+        expect(newUser).toStrictEqual({
+          _id: newUserId,
+          displayName: 'John',
+          email: 'user1@test.com',
+          introduction: '',
+          organization: '',
+          storage: {
+            planId: null,
+            usedBytes: 0,
+            reminders: []
+          },
+          favorites: [],
+          roles: [],
+          provider: 'educandu',
+          expires: null,
+          lockedOut: false,
+          passwordHash: null,
+          verificationCode: null,
+          accountClosedOn: now
+        });
+      });
+    });
+  });
+
 });

--- a/src/stores/user-store.js
+++ b/src/stores/user-store.js
@@ -51,6 +51,10 @@ class UserStore {
     return this.collection.findOne({ email, accountClosedOn: null }, { session });
   }
 
+  getUsersByEmailAddress(email, { session } = {}) {
+    return this.collection.find({ email }, { session }).toArray();
+  }
+
   saveUser(user, { session } = {}) {
     validate(user, userDBSchema);
     return this.collection.replaceOne({ _id: user._id }, user, { session, upsert: true });


### PR DESCRIPTION
Closes https://educandu.atlassian.net/browse/EDU-832

The original plan was to trigger the final import through Postman, using the `POST /api/v1/imports` endpoint.
However the body of this request is required to have alot more information about the imported documents than just the IDs.
I've implemented a simple(r) alternative though :) Through this, the steps needed to be followed for the final import are4 adjusted as mentioned here: https://educandu.atlassian.net/browse/EDU-835