### PR TITLE
EDU-924 Add option for image border in markdown-with-image plugin

### DIFF
--- a/migrations/educandu-2022-11-11-01-add-image-border-to-markdown-with-image-plugin.js
+++ b/migrations/educandu-2022-11-11-01-add-image-border-to-markdown-with-image-plugin.js
@@ -1,0 +1,60 @@
+/* eslint-disable camelcase, no-await-in-loop, no-console */
+export default class Educandu_2022_11_11_01_add_image_border_to_markdown_with_image_plugin {
+  constructor(db) {
+    this.db = db;
+  }
+
+  async collectionUp(collectionName) {
+    const result = await this.db.collection(collectionName).updateMany(
+      {},
+      {
+        $set: {
+          'sections.$[sectionElement].content.image.border': false
+        }
+      },
+      {
+        arrayFilters: [
+          {
+            'sectionElement.type': 'markdown-with-image',
+            'sectionElement.content': { $ne: null }
+          }
+        ],
+        multi: true
+      }
+    );
+
+    console.log(`Updated ${collectionName}: ${JSON.stringify(result)}`);
+  }
+
+  async collectionDown(collectionName) {
+    const result = await this.db.collection(collectionName).updateMany(
+      {},
+      {
+        $unset: {
+          'sections.$[sectionElement].content.image.border': null
+        }
+      },
+      {
+        arrayFilters: [
+          {
+            'sectionElement.type': 'markdown-with-image',
+            'sectionElement.content': { $ne: null }
+          }
+        ],
+        multi: true
+      }
+    );
+
+    console.log(`Updated ${collectionName}: ${JSON.stringify(result)}`);
+  }
+
+  async up() {
+    await this.collectionUp('documents');
+    await this.collectionUp('documentRevisions');
+  }
+
+  async down() {
+    await this.collectionDown('documents');
+    await this.collectionDown('documentRevisions');
+  }
+}

--- a/src/domain/schemas/user-schemas.js
+++ b/src/domain/schemas/user-schemas.js
@@ -83,7 +83,7 @@ export const userDBSchema = joi.object({
   roles: joi.array().required().items(joi.string()),
   expires: joi.date().allow(null).required(),
   verificationCode: joi.string().allow(null).required(),
-  lockedOut: joi.bool().required(),
+  lockedOut: joi.boolean().required(),
   storage: storageDBSchema.required(),
   favorites: joi.array().required().items(favoriteDBSchema),
   accountClosedOn: joi.date().allow(null).required(),

--- a/src/plugins/markdown-with-image/markdown-with-image-display.js
+++ b/src/plugins/markdown-with-image/markdown-with-image-display.js
@@ -17,6 +17,7 @@ export default function MarkdownWithImageDisplay({ content }) {
   const imageWrapperClasses = classNames(
     'MarkdownWithImageDisplay-imageWrapper',
     `u-width-${image.width}`,
+    { 'MarkdownWithImageDisplay-imageWrapper--bordered': image.border },
     { 'MarkdownWithImageDisplay-imageWrapper--left': image.position === IMAGE_POSITION.left },
     { 'MarkdownWithImageDisplay-imageWrapper--right': image.position === IMAGE_POSITION.right }
   );

--- a/src/plugins/markdown-with-image/markdown-with-image-editor.js
+++ b/src/plugins/markdown-with-image/markdown-with-image-editor.js
@@ -1,8 +1,8 @@
 import React, { Fragment } from 'react';
-import { Form, Radio, Tooltip } from 'antd';
 import { useTranslation } from 'react-i18next';
 import { IMAGE_POSITION } from './constants.js';
 import UrlInput from '../../components/url-input.js';
+import { Checkbox, Form, Radio, Tooltip } from 'antd';
 import { InfoCircleOutlined } from '@ant-design/icons';
 import ClientConfig from '../../bootstrap/client-config.js';
 import { ensureIsExcluded } from '../../utils/array-utils.js';
@@ -50,6 +50,11 @@ export default function MarkdownWithImageEditor({ content, onContentChanged }) {
     changeContent({ image: { ...image, width: value } });
   };
 
+  const handleImageBorderChange = event => {
+    const { checked } = event.target;
+    changeContent({ image: { ...image, border: checked } });
+  };
+
   const handleImagePositionChange = event => {
     const { value } = event.target;
     changeContent({ image: { ...image, position: value } });
@@ -93,6 +98,9 @@ export default function MarkdownWithImageEditor({ content, onContentChanged }) {
             <RadioButton value={IMAGE_POSITION.right}>{t('right')}</RadioButton>
           </RadioGroup>
         </FormItem>
+        <Form.Item label={t('imageBorder')} {...FORM_ITEM_LAYOUT}>
+          <Checkbox checked={image.border} onChange={handleImageBorderChange} />
+        </Form.Item>
       </Form>
     </div>
   );

--- a/src/plugins/markdown-with-image/markdown-with-image-info.js
+++ b/src/plugins/markdown-with-image/markdown-with-image-info.js
@@ -40,6 +40,7 @@ class MarkdownWithImageInfo {
         sourceUrl: '',
         width: 50,
         position: IMAGE_POSITION.left,
+        border: false,
         copyrightNotice: ''
       }
     };
@@ -52,6 +53,7 @@ class MarkdownWithImageInfo {
         sourceUrl: joi.string().allow('').required(),
         width: joi.number().min(0).max(100).required(),
         position: joi.string().valid(...Object.values(IMAGE_POSITION)).required(),
+        border: joi.boolean().required(),
         copyrightNotice: joi.string().allow('').required()
       }).required()
     });

--- a/src/plugins/markdown-with-image/markdown-with-image.less
+++ b/src/plugins/markdown-with-image/markdown-with-image.less
@@ -3,21 +3,26 @@
 }
 
 .MarkdownWithImageDisplay-imageWrapper {
-  padding: 10px 15px;
+  margin: 5px 15px 10px 15px;
 
   @media @edu-media-phone {
-    padding-left: 0;
-    padding-right: 0;
+    margin-left: 0;
+    margin-right: 0;
+  }
+
+  &.MarkdownWithImageDisplay-imageWrapper--bordered {
+    border: 1px solid @edu-border-color-base;
+    padding: 5px;
   }
 
   &.MarkdownWithImageDisplay-imageWrapper--left {
     float: left;
-    padding-left: 0;
+    margin-left: 0;
   }
 
   &.MarkdownWithImageDisplay-imageWrapper--right {
     float: right;
-    padding-right: 0;
+    margin-right: 0;
   }
 }
 

--- a/src/plugins/markdown-with-image/markdown-with-image.yml
+++ b/src/plugins/markdown-with-image/markdown-with-image.yml
@@ -10,6 +10,9 @@ imageWidth:
 imagePosition:
   en: Image position
   de: Bildstelle
+imageBorder:
+  en: Image border
+  de: Bildrahmen
 left:
   en: left
   de: Links

--- a/src/resources/resources.json
+++ b/src/resources/resources.json
@@ -2005,6 +2005,7 @@
       "imageUrl": "Image URL",
       "imageWidth": "Image width",
       "imagePosition": "Image position",
+      "imageBorder": "Image border",
       "left": "left",
       "right": "right"
     }
@@ -2017,6 +2018,7 @@
       "imageUrl": "Bild-URL",
       "imageWidth": "Bildbreite",
       "imagePosition": "Bildstelle",
+      "imageBorder": "Bildrahmen",
       "left": "Links",
       "right": "Rechts"
     }


### PR DESCRIPTION
Closes https://educandu.atlassian.net/browse/EDU-924

Looks good on most images:

![looksgood](https://user-images.githubusercontent.com/2676617/201316443-ceb4aa9e-4755-44ea-a187-0d0cb951861a.png)

Looks not so great on music:

![looksbad](https://user-images.githubusercontent.com/2676617/201316516-c3ea971f-1a54-4bd6-802d-4ce91b74e451.png)

On whether the copyright should be inside or outside the border, to me there's not much difference, I opted for the solution requiring less HTML/CSS (inside).