### PR TITLE
EDU-943 Fix list styling in markdown

### DIFF
--- a/src/components/markdown.less
+++ b/src/components/markdown.less
@@ -65,6 +65,12 @@
     font-weight: normal;
   }
 
+  ol, dl, ul {
+    overflow: hidden;
+    padding-left: 2.5em;
+    list-style-position: outside;
+  }
+
   hr {
     display: block;
     height: 1px;


### PR DESCRIPTION
Closes https://educandu.atlassian.net/browse/EDU-943

I also decreased the left padding for each list level in general from around 3em to 2.5em which I find looks better.

Before:

![before](https://user-images.githubusercontent.com/2676617/202621108-dfd10689-6a94-452f-acb8-c38d2b784d75.png)

After:

![after](https://user-images.githubusercontent.com/2676617/202621226-227af7f1-2d58-48b3-a047-1ee16088ce43.png)
