### PR TITLE
EDU-951 Partial fix for youtube video auto-play scenario

### DIFF
--- a/src/components/media-player/media-player-track-group.js
+++ b/src/components/media-player/media-player-track-group.js
@@ -89,6 +89,7 @@ function MediaPlayerTrackGroup({
   onDuration,
   onProgress,
   onEndReached,
+  onInvalidStateReached,
   onPlayStateChange,
   sources
 }) {
@@ -292,6 +293,7 @@ function MediaPlayerTrackGroup({
         loadImmediately={isMultitrack || loadImmediately}
         onDuration={handleMainTrackDuration}
         onEndReached={handleMainTrackEndReached}
+        onInvalidStateReached={onInvalidStateReached}
         onProgress={handleMainTrackProgress}
         onPlayStateChange={handleMainTrackPlayStateChange}
         />
@@ -329,6 +331,7 @@ MediaPlayerTrackGroup.propTypes = {
   loadImmediately: PropTypes.bool,
   onDuration: PropTypes.func,
   onEndReached: PropTypes.func,
+  onInvalidStateReached: PropTypes.func,
   onPlayStateChange: PropTypes.func,
   onProgress: PropTypes.func,
   playbackRate: PropTypes.number,
@@ -360,6 +363,7 @@ MediaPlayerTrackGroup.defaultProps = {
   loadImmediately: false,
   onDuration: () => {},
   onEndReached: () => {},
+  onInvalidStateReached: () => {},
   onPlayStateChange: () => {},
   onProgress: () => {},
   playbackRate: 1,

--- a/src/components/media-player/media-player-track.js
+++ b/src/components/media-player/media-player-track.js
@@ -206,8 +206,6 @@ function MediaPlayerTrack({
   const isBufferingWhilePlaying = trackPlayState.current === MEDIA_PLAY_STATE.buffering && trackPlayState.beforeBuffering === MEDIA_PLAY_STATE.playing;
   const shouldPlay = trackPlayState.current === MEDIA_PLAY_STATE.playing || isBufferingWhilePlaying;
 
-  const thumbnailForLightMode = loadImmediately ? false : trackPlayState.current === MEDIA_PLAY_STATE.initializing && (posterImageUrl || true);
-
   return (
     <div className={classes}>
       <div className="MediaPlayerTrack-aspectRatioContainer" style={{ paddingTop }}>
@@ -222,7 +220,7 @@ function MediaPlayerTrack({
           muted={volume === 0}
           playbackRate={playbackRate}
           progressInterval={MEDIA_PROGRESS_INTERVAL_IN_MILLISECONDS}
-          light={thumbnailForLightMode}
+          light={loadImmediately ? false : trackPlayState.current === MEDIA_PLAY_STATE.initializing && (posterImageUrl || true)}
           playing={shouldPlay}
           onReady={handleReady}
           onBuffer={handleBuffer}

--- a/src/components/media-player/media-player-track.js
+++ b/src/components/media-player/media-player-track.js
@@ -150,16 +150,6 @@ function MediaPlayerTrack({
     const currentSourceTimestamp = progress.played * sourceDuration;
     const trackStopTimecode = lastPlaybackRange[1] * sourceDuration;
 
-    // This unbexpected case only occurs when the react-player rerenders, having
-    // loaded, played and paused a youtube resource before that.
-    // In this case the react-player automatically plays, disregarding the value passed to the "playing" prop.
-    // This solution stops the auto-play on re-render, however the react-player's internal state is damaged
-    // from this point on, the state change of the "playing" prop not being handled correctly
-    if (trackPlayState.current === MEDIA_PLAY_STATE.pausing && progress.played === 0) {
-      playerRef.current.getInternalPlayer()?.pauseVideo();
-      return;
-    }
-
     if (currentSourceTimestamp > trackStopTimecode && trackStopTimecode !== lastProgressTimecode) {
       setTrackPlayState({
         current: MEDIA_PLAY_STATE.stopped,

--- a/src/components/media-player/multitrack-media-player.js
+++ b/src/components/media-player/multitrack-media-player.js
@@ -3,6 +3,7 @@ import classNames from 'classnames';
 import { useTranslation } from 'react-i18next';
 import cloneDeep from '../../utils/clone-deep.js';
 import { useService } from '../container-context.js';
+import { remountWhen } from '../../ui/react-helper.js';
 import { useDedupedCallback } from '../../ui/hooks.js';
 import HttpClient from '../../api-clients/http-client.js';
 import React, { useEffect, useRef, useState } from 'react';
@@ -87,6 +88,7 @@ function MultitrackMediaPlayer({
   onSelectedVolumePresetChange,
   onPartEndReached,
   onEndReached,
+  onInvalidStateReached,
   onProgress,
   onPlayStateChange,
   onPlayingPartIndexChange,
@@ -316,6 +318,7 @@ function MultitrackMediaPlayer({
           playbackRate={playbackRate}
           onDuration={handleDuration}
           onEndReached={handleEndReached}
+          onInvalidStateReached={onInvalidStateReached}
           onProgress={handleProgress}
           onPlayStateChange={handlePlayStateChange}
           posterImageUrl={posterImageUrl}
@@ -369,6 +372,7 @@ MultitrackMediaPlayer.propTypes = {
     current: PropTypes.any
   }),
   onEndReached: PropTypes.func,
+  onInvalidStateReached: PropTypes.func,
   onPartEndReached: PropTypes.func,
   onPlayStateChange: PropTypes.func,
   onPlayingPartIndexChange: PropTypes.func,
@@ -416,6 +420,7 @@ MultitrackMediaPlayer.defaultProps = {
     current: null
   },
   onEndReached: () => {},
+  onInvalidStateReached: () => {},
   onPartEndReached: () => {},
   onPlayStateChange: () => {},
   onPlayingPartIndexChange: () => {},
@@ -434,4 +439,4 @@ MultitrackMediaPlayer.defaultProps = {
   volumePresetOptions: []
 };
 
-export default MultitrackMediaPlayer;
+export default remountWhen(MultitrackMediaPlayer, 'onInvalidStateReached');

--- a/src/components/media-player/preloading-media-player-track.js
+++ b/src/components/media-player/preloading-media-player-track.js
@@ -23,6 +23,7 @@ function PreloadingMediaPlayerTrack({
   onDuration,
   onProgress,
   onEndReached,
+  onInvalidStateReached,
   onPlayStateChange
 }) {
   const httpClient = useService(HttpClient);
@@ -95,6 +96,7 @@ function PreloadingMediaPlayerTrack({
       onDuration={onDuration}
       onProgress={onProgress}
       onEndReached={onEndReached}
+      onInvalidStateReached={onInvalidStateReached}
       onPlayStateChange={onPlayStateChange}
       />
   );
@@ -105,6 +107,7 @@ PreloadingMediaPlayerTrack.propTypes = {
   loadImmediately: PropTypes.bool,
   onDuration: PropTypes.func,
   onEndReached: PropTypes.func,
+  onInvalidStateReached: PropTypes.func,
   onPlayStateChange: PropTypes.func,
   onProgress: PropTypes.func,
   playbackRange: PropTypes.arrayOf(PropTypes.number),
@@ -125,6 +128,7 @@ PreloadingMediaPlayerTrack.defaultProps = {
   loadImmediately: false,
   onDuration: () => {},
   onEndReached: () => {},
+  onInvalidStateReached: () => {},
   onPlayStateChange: () => {},
   onProgress: () => {},
   playbackRange: [0, 1],

--- a/src/components/pages/revision.js
+++ b/src/components/pages/revision.js
@@ -7,22 +7,12 @@ import { documentRevisionShape } from '../../ui/default-prop-types.js';
 function Revision({ initialState, PageTemplate }) {
   const { revision } = initialState;
 
-  const publicStorage = {
-    rootPath: 'media',
-    homePath: `media/${revision.documentId}`,
-    isDeletionEnabled: false
-  };
-
   return (
     <PageTemplate >
       <div className="RevisionPage">
-        <SectionsDisplay
-          sections={revision.sections}
-          publicStorage={publicStorage}
-          canEdit={false}
-          />
+        <SectionsDisplay sections={revision.sections} />
+        <CreditsFooter revision={revision} />
       </div>
-      <CreditsFooter revision={revision} />
     </PageTemplate>
   );
 }

--- a/src/components/section-display.js
+++ b/src/components/section-display.js
@@ -31,12 +31,15 @@ function SectionDisplay({
   canHardDelete,
   dragHandleProps,
   isDragged,
+  isEditing,
   isOtherSectionDragged,
   isPending,
   onPendingSectionApply,
   onPendingSectionDiscard,
   onSectionDuplicate,
   onSectionDelete,
+  onSectionEditEnter,
+  onSectionEditLeave,
   onSectionMoveUp,
   onSectionMoveDown,
   onSectionContentChange,
@@ -50,7 +53,6 @@ function SectionDisplay({
 
   const isHardDeleteEnabled = canHardDelete && !section.deletedOn;
 
-  const [isEditing, setIsEditing] = useState(false);
   const [isInvalid, setIsInvalid] = useState(false);
   const [isHelpModalVisible, setIsHelpModalVisible] = useState(false);
 
@@ -87,7 +89,7 @@ function SectionDisplay({
       type: 'edit',
       tooltip: renderActionTooltip('edit', ['ctrl', 'click']),
       icon: <EditIcon key="edit" />,
-      handleAction: () => setIsEditing(true),
+      handleAction: () => onSectionEditEnter(),
       isVisible: !isEditing,
       isEnabled: !isEditing && !!section.content
     },
@@ -95,7 +97,7 @@ function SectionDisplay({
       type: 'preview',
       tooltip: renderActionTooltip('preview', ['ctrl', 'click']),
       icon: <PreviewIcon key="preview" />,
-      handleAction: () => setIsEditing(false),
+      handleAction: () => onSectionEditLeave(),
       isVisible: isEditing,
       isEnabled: isEditing
     },
@@ -222,7 +224,11 @@ function SectionDisplay({
           onSectionDuplicate();
         }
       } else if (section.content) {
-        setIsEditing(!isEditing);
+        if (isEditing) {
+          onSectionEditLeave();
+        } else {
+          onSectionEditEnter();
+        }
       }
     }
   };
@@ -302,6 +308,7 @@ SectionDisplay.propTypes = {
   canHardDelete: PropTypes.bool.isRequired,
   dragHandleProps: PropTypes.object.isRequired,
   isDragged: PropTypes.bool.isRequired,
+  isEditing: PropTypes.bool.isRequired,
   isOtherSectionDragged: PropTypes.bool.isRequired,
   isPending: PropTypes.bool.isRequired,
   onPendingSectionApply: PropTypes.func.isRequired,
@@ -310,6 +317,8 @@ SectionDisplay.propTypes = {
   onSectionCopyToClipboard: PropTypes.func.isRequired,
   onSectionDelete: PropTypes.func.isRequired,
   onSectionDuplicate: PropTypes.func.isRequired,
+  onSectionEditEnter: PropTypes.func.isRequired,
+  onSectionEditLeave: PropTypes.func.isRequired,
   onSectionHardDelete: PropTypes.func.isRequired,
   onSectionMoveDown: PropTypes.func.isRequired,
   onSectionMoveUp: PropTypes.func.isRequired,
@@ -321,6 +330,8 @@ export default memoAndTransformProps(SectionDisplay, ({
   onPendingSectionDiscard,
   onSectionDuplicate,
   onSectionDelete,
+  onSectionEditEnter,
+  onSectionEditLeave,
   onSectionMoveUp,
   onSectionMoveDown,
   onSectionContentChange,
@@ -332,6 +343,8 @@ export default memoAndTransformProps(SectionDisplay, ({
   onPendingSectionDiscard: useStableCallback(onPendingSectionDiscard),
   onSectionDuplicate: useStableCallback(onSectionDuplicate),
   onSectionDelete: useStableCallback(onSectionDelete),
+  onSectionEditEnter: useStableCallback(onSectionEditEnter),
+  onSectionEditLeave: useStableCallback(onSectionEditLeave),
   onSectionMoveUp: useStableCallback(onSectionMoveUp),
   onSectionMoveDown: useStableCallback(onSectionMoveDown),
   onSectionContentChange: useStableCallback(onSectionContentChange),

--- a/src/components/sections-display.js
+++ b/src/components/sections-display.js
@@ -70,7 +70,7 @@ function SectionsDisplay({
 
   const renderSection = ({ section, index, dragHandleProps = {}, isDragged = false }) => {
     return (<SectionDisplay
-      key={`${section.key}-${index}`}
+      key={section.key}
       section={section}
       canEdit={!!dragHandleProps && canEdit}
       canHardDelete={canHardDelete}

--- a/src/components/sections-display.js
+++ b/src/components/sections-display.js
@@ -67,7 +67,7 @@ function SectionsDisplay({
 
   const renderSection = ({ section, index, dragHandleProps = {}, isDragged = false }) => {
     return (<SectionDisplay
-      key={section.key}
+      key={`${section.key}-${index}`}
       section={section}
       canEdit={!!dragHandleProps && canEdit}
       canHardDelete={canHardDelete}

--- a/src/components/sections-display.js
+++ b/src/components/sections-display.js
@@ -12,12 +12,15 @@ function SectionsDisplay({
   pendingSectionKeys,
   canEdit,
   canHardDelete,
+  editedSectionKeys,
   onPendingSectionApply,
   onPendingSectionDiscard,
   onSectionMove,
   onSectionInsert,
   onSectionDuplicate,
   onSectionDelete,
+  onSectionEditEnter,
+  onSectionEditLeave,
   onSectionContentChange,
   onSectionCopyToClipboard,
   onSectionPasteFromClipboard,
@@ -73,6 +76,7 @@ function SectionsDisplay({
       canHardDelete={canHardDelete}
       dragHandleProps={dragHandleProps}
       isDragged={isDragged}
+      isEditing={editedSectionKeys.includes(section.key)}
       isOtherSectionDragged={isDragging && !isDragged}
       isPending={pendingSectionKeys.includes(section.key)}
       onPendingSectionApply={() => onPendingSectionApply(index)}
@@ -80,6 +84,8 @@ function SectionsDisplay({
       onSectionCopyToClipboard={() => onSectionCopyToClipboard(index)}
       onSectionDelete={() => onSectionDelete(index)}
       onSectionDuplicate={() => onSectionDuplicate(index)}
+      onSectionEditEnter={() => onSectionEditEnter(index)}
+      onSectionEditLeave={() => onSectionEditLeave(index)}
       onSectionMoveUp={() => handleSectionMove(index, index - 1)}
       onSectionMoveDown={() => handleSectionMove(index, index + 1)}
       onSectionContentChange={(newContent, isInvalid) => onSectionContentChange(index, newContent, isInvalid)}
@@ -155,12 +161,15 @@ function SectionsDisplay({
 SectionsDisplay.propTypes = {
   canEdit: PropTypes.bool,
   canHardDelete: PropTypes.bool,
+  editedSectionKeys: PropTypes.arrayOf(PropTypes.string),
   onPendingSectionApply: PropTypes.func,
   onPendingSectionDiscard: PropTypes.func,
   onSectionContentChange: PropTypes.func,
   onSectionCopyToClipboard: PropTypes.func,
   onSectionDelete: PropTypes.func,
   onSectionDuplicate: PropTypes.func,
+  onSectionEditEnter: PropTypes.func,
+  onSectionEditLeave: PropTypes.func,
   onSectionHardDelete: PropTypes.func,
   onSectionInsert: PropTypes.func,
   onSectionMove: PropTypes.func,
@@ -172,12 +181,15 @@ SectionsDisplay.propTypes = {
 SectionsDisplay.defaultProps = {
   canEdit: false,
   canHardDelete: false,
+  editedSectionKeys: [],
   onPendingSectionApply: () => {},
   onPendingSectionDiscard: () => {},
   onSectionContentChange: () => {},
   onSectionCopyToClipboard: () => {},
   onSectionDelete: () => {},
   onSectionDuplicate: () => {},
+  onSectionEditEnter: () => {},
+  onSectionEditLeave: () => {},
   onSectionHardDelete: () => {},
   onSectionInsert: () => {},
   onSectionMove: () => {},

--- a/src/ui/react-helper.js
+++ b/src/ui/react-helper.js
@@ -1,8 +1,23 @@
-import React, { memo } from 'react';
+import React, { memo, useCallback, useState } from 'react';
 
 export function memoAndTransformProps(Component, transformProps) {
   const MemoizedComponent = memo(Component);
-  return function MemoTransform(props) {
+  return function MemoTransformWrapper(props) {
     return <MemoizedComponent {...transformProps(props)} />;
+  };
+}
+
+export function remountWhen(Component, eventName) {
+  return function RemountWrapper(props) {
+    const [key, setKey] = useState(0);
+    const handleRemountTrigger = useCallback(() => {
+      setKey(oldKey => oldKey + 1);
+    }, [setKey]);
+    const innerProps = {
+      ...props,
+      [eventName]: handleRemountTrigger,
+      key
+    };
+    return <Component {...innerProps} />;
   };
 }


### PR DESCRIPTION
Closes https://educandu.atlassian.net/browse/EDU-951

After spending more than one day on this issue, I have currently drawn the line at transforming the bug into a different bug we could live with until we want to invest more time in this.

The situation is as follows:
- when a media plugin section sets a youtube URL as its `sourceUrl`, then plays and pauses it, then moves another section up, before it, the `react-player` starts disregarding the `false` value we pass to its `playing` param and starts auto-playing the video
- it seems the `react-player` ends up in an incorrect state from this point on
- using a `ref` for the value we pass to the `playing` param of the `react-player` does not solve the issue of its state change being disregarded in the described scenario
- manually pausing the video has the effect of stopping the auto-play; however the `playing` state change continues to not function correctly passed this point
- there is no auto-play actually enabled on the `react-player`, at least not that I could find by drilling into the `playerRef` data

This change transforms the existing bug so that the video no longer auto plays, however once the user clicks to play from our custom controls, the media starts playing and can no longer be paused through the controls (clicking pause has no effect anymore). When a youtube video is loaded in the `video` section (as opposed to an `audio` section), playing and pausing can still be done by clicking the video directly.