### PR TITLE
EDU-1002 Use plyr instead of react-player in video and audio plugins

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "passport": "^0.6.0",
     "passport-local": "^1.0.0",
     "passport-strategy": "^1.0.0",
+    "plyr": "^3.7.3",
     "pretty-bytes": "^6.0.0",
     "prop-types": "^15.8.1",
     "react": "^18.2.0",

--- a/src/components/media-player/plyr/media-playback.js
+++ b/src/components/media-player/plyr/media-playback.js
@@ -1,0 +1,239 @@
+import Plyr from 'plyr';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+import { useService } from '../../container-context.js';
+import { useStableCallback } from '../../../ui/hooks.js';
+import { useYoutubeThumbnailUrl } from '../media-hooks.js';
+import PlayIcon from '../../icons/media-player/play-icon.js';
+import { getSourceType } from '../../../utils/source-utils.js';
+import ClientConfig from '../../../bootstrap/client-config.js';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { memoAndTransformProps } from '../../../ui/react-helper.js';
+import {
+  SOURCE_TYPE,
+  YOUTUBE_STATE,
+  MEDIA_ASPECT_RATIO,
+  MEDIA_PROGRESS_INTERVAL_IN_MILLISECONDS,
+} from '../../../domain/constants.js';
+
+function MediaPlayback({
+  volume,
+  audioOnly,
+  sourceUrl,
+  aspectRatio,
+  playbackRate,
+  posterImageUrl,
+  mediaPlaybackRef,
+  onReady,
+  onPlay,
+  onPause,
+  onEnded,
+  onDuration,
+  onProgress,
+  onBuffering
+}) {
+  const plyrRef = useRef(null);
+  const progressInterval = useRef(null);
+  const [player, setPlayer] = useState(null);
+  const youtubeThumbnailUrl = useYoutubeThumbnailUrl(sourceUrl);
+  const [couldShowOverlay, setCouldShowOverlay] = useState(true);
+
+  const clientConfig = useService(ClientConfig);
+
+  const sourceType = useMemo(() => {
+    return getSourceType({ url: sourceUrl, cdnRootUrl: clientConfig.cdnRootUrl });
+  }, [sourceUrl, clientConfig]);
+
+  const setProgressInterval = callback => {
+    if (!callback) {
+      clearInterval(progressInterval.current);
+      progressInterval.current = null;
+      return;
+    }
+    progressInterval.current = setInterval(callback, MEDIA_PROGRESS_INTERVAL_IN_MILLISECONDS);
+  };
+
+  useEffect(() => {
+    const playerInstance = new Plyr(plyrRef.current, {
+      controls: [],
+      ratio: aspectRatio,
+      clickToPlay: true,
+      loadSprite: false,
+      fullscreen: { enabled: false, fallback: false },
+      // https://developers.google.com/youtube/player_parameters#Parameters
+      youtube: { autoplay: 0, rel: 0, fs: 0, showinfo: 0, disablekb: 1, iv_load_policy: 3, modestbranding: 0, controls: 0 }
+    });
+    setPlayer(playerInstance);
+  }, [plyrRef, aspectRatio]);
+
+  useEffect(() => {
+    if (player) {
+      player.source = {
+        type: audioOnly ? 'audio': 'video',
+        sources: [{
+          src: sourceUrl,
+          provider: sourceType === SOURCE_TYPE.youtube ? 'youtube' : 'html5'
+        }]
+      };
+    }
+  }, [player, sourceUrl, audioOnly, sourceType]);
+
+  useEffect(() => {
+    if (player) {
+      player.speed = playbackRate;
+    }
+  }, [player, playbackRate]);
+
+  useEffect(() => {
+    if (player) {
+      player.volume = volume;
+    }
+  }, [player, volume]);
+
+  useEffect(() => {
+    if (player) {
+      if (posterImageUrl) {
+        player.poster = posterImageUrl;
+        return;
+      }
+      if (youtubeThumbnailUrl) {
+        player.poster = youtubeThumbnailUrl.isHighResThumbnailUrlVerfied
+          ? youtubeThumbnailUrl.highResThumbnailUrl
+          : youtubeThumbnailUrl.lowResThumbnailUrl;
+      }
+    }
+  }, [player, audioOnly, posterImageUrl, youtubeThumbnailUrl]);
+
+  useEffect(() => {
+    if (player) {
+      player.on('loadedmetadata', async () => {
+        if (player.duration) {
+          onDuration(player.duration * 1000);
+        }
+      });
+      player.on('ready', () => {
+        if (player.duration) {
+          onDuration(player.duration * 1000);
+        }
+        onReady();
+      });
+      player.on('playing', async () => {
+        onPlay();
+        setCouldShowOverlay(false);
+        setProgressInterval(() => onProgress(player.currentTime * 1000));
+      });
+      player.on('pause', () => {
+        setProgressInterval(null);
+        setCouldShowOverlay(true);
+        onPause();
+      });
+      player.on('seeking', () => {
+        onProgress(player.currentTime * 1000);
+      });
+      player.on('progress', () => {
+        onProgress(player.currentTime * 1000);
+      });
+      player.on('timeupdate', () => {
+        onProgress(player.currentTime * 1000);
+      });
+      player.on('ended', () => {
+        setProgressInterval(null);
+        onEnded();
+      });
+      // youtube-only event
+      player.on('statechange', event => {
+        onProgress(player.currentTime * 1000);
+        if (event.detail.code === YOUTUBE_STATE.buffering) {
+          setProgressInterval(null);
+          onBuffering();
+        }
+      });
+    }
+  }, [player, sourceUrl, onReady, onPlay, onPause, onEnded, onDuration, onProgress, onBuffering]);
+
+  const handleOverlayClick = () => {
+    player?.play();
+  };
+
+  mediaPlaybackRef.current = useMemo(() => ({
+    play: player?.play,
+    pause: player?.pause,
+    seekToTimecode: milliseconds => {
+      if (player) {
+        player.currentTime = milliseconds / 1000;
+      }
+    }
+  }), [player]);
+
+  const showOverlay = !audioOnly && sourceType !== SOURCE_TYPE.youtube && couldShowOverlay;
+
+  return (
+    <div className={classNames('MediaPlayback', { 'MediaPlayback--audioOnly': audioOnly } )}>
+      <video crossOrigin="true" ref={plyrRef} />
+      {showOverlay && (
+        <div className="MediaPlayback-videoOverlay" onClick={handleOverlayClick} >
+          <div className="MediaPlayback-videoOverlayIcon">
+            <PlayIcon />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+MediaPlayback.propTypes = {
+  volume: PropTypes.number.isRequired,
+  audioOnly: PropTypes.bool,
+  sourceUrl: PropTypes.string.isRequired,
+  aspectRatio: PropTypes.oneOf(Object.values(MEDIA_ASPECT_RATIO)),
+  onReady: PropTypes.func,
+  onPlay: PropTypes.func,
+  onPause: PropTypes.func,
+  onEnded: PropTypes.func,
+  onDuration: PropTypes.func,
+  onProgress: PropTypes.func,
+  onBuffering: PropTypes.func,
+  onBufferingEnded: PropTypes.func,
+  playbackRate: PropTypes.number,
+  posterImageUrl: PropTypes.string,
+  mediaPlaybackRef: PropTypes.shape({
+    current: PropTypes.any
+  }),
+};
+
+MediaPlayback.defaultProps = {
+  audioOnly: false,
+  aspectRatio: MEDIA_ASPECT_RATIO.sixteenToNine,
+  onReady: () => {},
+  onPlay: () => {},
+  onPause: () => {},
+  onEnded: () => {},
+  onDuration: () => {},
+  onProgress: () => {},
+  onBuffering: () => {},
+  playbackRate: 1,
+  posterImageUrl: null,
+  mediaPlaybackRef: {
+    current: null
+  }
+};
+
+export default memoAndTransformProps(MediaPlayback, ({
+  onReady,
+  onPlay,
+  onPause,
+  onEnded,
+  onDuration,
+  onProgress,
+  onBuffering,
+  ...rest
+}) => ({
+  onReady: useStableCallback(onReady),
+  onPlay: useStableCallback(onPlay),
+  onPause: useStableCallback(onPause),
+  onEnded: useStableCallback(onEnded),
+  onDuration: useStableCallback(onDuration),
+  onProgress: useStableCallback(onProgress),
+  onBuffering: useStableCallback(onBuffering),
+  ...rest
+}));

--- a/src/components/media-player/plyr/media-playback.less
+++ b/src/components/media-player/plyr/media-playback.less
@@ -1,0 +1,35 @@
+@import (less) 'plyr/dist/plyr.css';
+
+.MediaPlayback {
+  --plyr-video-background: @edu-white;
+  position: relative;
+
+  &.MediaPlayback--audioOnly iframe {
+    width: 0;
+    height: 0;
+  }
+}
+
+.MediaPlayback-videoOverlay {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.MediaPlayback-videoOverlayIcon {
+  .m-box-shadow;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 50px;
+  height: 50px;
+  font-size: 25px;
+  color: @edu-white;
+  border-radius: 50%;
+  background: rgba(0, 0, 0, 0.4);
+}

--- a/src/components/media-player/plyr/media-playback.less
+++ b/src/components/media-player/plyr/media-playback.less
@@ -2,6 +2,7 @@
 
 .MediaPlayback {
   --plyr-video-background: @edu-white;
+  cursor: pointer;
   position: relative;
 
   &.MediaPlayback--audioOnly iframe {

--- a/src/components/media-player/plyr/media-player.js
+++ b/src/components/media-player/plyr/media-player.js
@@ -1,0 +1,147 @@
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+import MediaPlayback from './media-playback.js';
+import React, { useRef, useState } from 'react';
+import { useService } from '../../container-context.js';
+import HttpClient from '../../../api-clients/http-client.js';
+import MediaPlayerControls from '../media-player-controls.js';
+import ClientConfig from '../../../bootstrap/client-config.js';
+import MediaPlayerProgressBar from '../media-player-progress-bar.js';
+import { isInternalSourceType } from '../../../utils/source-utils.js';
+import {
+  MEDIA_PLAY_STATE,
+  MEDIA_SCREEN_MODE,
+  MEDIA_ASPECT_RATIO,
+} from '../../../domain/constants.js';
+
+function MediaPlayer({
+  sourceUrl,
+  screenMode,
+  aspectRatio,
+  canDownload,
+  downloadFileName,
+  posterImageUrl,
+  mediaPlayerRef
+}) {
+  const mediaPlaybackRef = useRef();
+  const [volume, setVolume] = useState(1);
+  const httpClient = useService(HttpClient);
+  const clientConfig = useService(ClientConfig);
+  const [playbackRate, setPlaybackRate] = useState(1);
+  const [playedMilliseconds, setPlayedMilliseconds] = useState(0);
+  const [durationInMilliseconds, setDurationInMilliseconds] = useState(0);
+  const [playState, setPlayState] = useState(MEDIA_PLAY_STATE.initializing);
+
+  const handleDuration = newDurationInMilliseconds => {
+    setDurationInMilliseconds(newDurationInMilliseconds);
+  };
+
+  const handleProgress = progressInMilliseconds => {
+    setPlayedMilliseconds(progressInMilliseconds);
+  };
+
+  const handlePlayClick = async () => {
+    mediaPlaybackRef.current.play();
+  };
+
+  const handlePlaying = () => {
+    setPlayState(MEDIA_PLAY_STATE.playing);
+  };
+
+  const handlePauseClick = () => {
+    mediaPlaybackRef.current.pause();
+    setPlayState(MEDIA_PLAY_STATE.pausing);
+  };
+
+  const handlePausing = () => {
+    setPlayState(MEDIA_PLAY_STATE.pausing);
+  };
+
+  const handleEnded= () => {
+    setPlayState(MEDIA_PLAY_STATE.stopped);
+  };
+
+  const handleSeek = milliseconds => {
+    mediaPlaybackRef.current.seekToTimecode(milliseconds);
+  };
+
+  const handleBuffering = () => {
+    setPlayState(MEDIA_PLAY_STATE.buffering);
+  };
+
+  const handlePlaybackRateChange = newRate => {
+    setPlaybackRate(newRate);
+  };
+
+  const handleDownloadClick = async () => {
+    const withCredentials = isInternalSourceType({ url: sourceUrl, cdnRootUrl: clientConfig.cdnRootUrl });
+    httpClient.download(sourceUrl, downloadFileName, withCredentials);
+  };
+
+  mediaPlayerRef.current = {
+    play: mediaPlaybackRef.current?.play,
+    pause: mediaPlaybackRef.current?.pause
+  };
+
+  return (
+    <div className={classNames('MediaPlayer', { 'MediaPlayer--noScreen': screenMode === MEDIA_SCREEN_MODE.none })}>
+      <MediaPlayback
+        volume={volume}
+        sourceUrl={sourceUrl}
+        aspectRatio={aspectRatio}
+        playbackRate={playbackRate}
+        posterImageUrl={posterImageUrl}
+        mediaPlaybackRef={mediaPlaybackRef}
+        audioOnly={screenMode !== MEDIA_SCREEN_MODE.video}
+        onPlay={handlePlaying}
+        onPause={handlePausing}
+        onEnded={handleEnded}
+        onDuration={handleDuration}
+        onProgress={handleProgress}
+        onBuffering={handleBuffering}
+        />
+      <MediaPlayerProgressBar
+        playedMilliseconds={playedMilliseconds}
+        durationInMilliseconds={durationInMilliseconds}
+        onSeek={handleSeek}
+        />
+      <MediaPlayerControls
+        volume={volume}
+        playState={playState}
+        screenMode={screenMode}
+        playedMilliseconds={playedMilliseconds}
+        durationInMilliseconds={durationInMilliseconds}
+        onVolumeChange={setVolume}
+        onPlayClick={handlePlayClick}
+        onPauseClick={handlePauseClick}
+        onPlaybackRateChange={handlePlaybackRateChange}
+        onDownloadClick={canDownload ? handleDownloadClick : null}
+        />
+    </div>
+  );
+}
+
+MediaPlayer.propTypes = {
+  sourceUrl: PropTypes.string.isRequired,
+  screenMode: PropTypes.oneOf(Object.values(MEDIA_SCREEN_MODE)),
+  aspectRatio: PropTypes.oneOf(Object.values(MEDIA_ASPECT_RATIO)),
+  downloadFileName: PropTypes.string,
+  canDownload: PropTypes.bool,
+  posterImageUrl: PropTypes.string,
+  mediaPlayerRef: PropTypes.shape({
+    current: PropTypes.any
+  }),
+};
+
+MediaPlayer.defaultProps = {
+  aspectRatio: MEDIA_ASPECT_RATIO.sixteenToNine,
+  screenMode: MEDIA_SCREEN_MODE.video,
+  canDownload: false,
+  downloadFileName: null,
+  posterImageUrl: null,
+  mediaPlayerRef: {
+    current: null
+  }
+};
+
+export default MediaPlayer;

--- a/src/components/media-player/plyr/media-player.less
+++ b/src/components/media-player/plyr/media-player.less
@@ -1,0 +1,8 @@
+.MediaPlayer {
+
+  &.MediaPlayer--noScreen {
+    padding: 15px;
+    border-radius: @edu-border-radius-base;
+    background-color: @edu-background-color-light;
+  }
+}

--- a/src/domain/constants.js
+++ b/src/domain/constants.js
@@ -231,3 +231,12 @@ export const HTTP_STATUS = {
   tooManyRequests: 429,
   internalServerError: 500
 };
+
+export const YOUTUBE_STATE = {
+  unstarted: -1,
+  ended: 0,
+  playing: 1,
+  paused: 2,
+  buffering: 3,
+  videoCued: 5
+};

--- a/src/plugins/audio/audio-display.js
+++ b/src/plugins/audio/audio-display.js
@@ -4,7 +4,7 @@ import { MEDIA_SCREEN_MODE } from '../../domain/constants.js';
 import { useService } from '../../components/container-context.js';
 import CopyrightNotice from '../../components/copyright-notice.js';
 import { sectionDisplayProps } from '../../ui/default-prop-types.js';
-import MediaPlayer from '../../components/media-player/media-player.js';
+import MediaPlayer from '../../components/media-player/plyr/media-player.js';
 import { getAccessibleUrl, isInternalSourceType } from '../../utils/source-utils.js';
 
 function AudioDisplay({ content }) {
@@ -18,7 +18,7 @@ function AudioDisplay({ content }) {
       <div className="AudioDisplay-content">
         {!!url && (
           <MediaPlayer
-            source={url}
+            sourceUrl={url}
             canDownload={canDownload}
             screenMode={MEDIA_SCREEN_MODE.none}
             />

--- a/src/plugins/video/video-display.js
+++ b/src/plugins/video/video-display.js
@@ -3,7 +3,7 @@ import ClientConfig from '../../bootstrap/client-config.js';
 import { useService } from '../../components/container-context.js';
 import CopyrightNotice from '../../components/copyright-notice.js';
 import { sectionDisplayProps } from '../../ui/default-prop-types.js';
-import MediaPlayer from '../../components/media-player/media-player.js';
+import MediaPlayer from '../../components/media-player/plyr/media-player.js';
 import { getAccessibleUrl, isInternalSourceType } from '../../utils/source-utils.js';
 
 function VideoDisplay({ content }) {
@@ -18,7 +18,7 @@ function VideoDisplay({ content }) {
       <div className={`VideoDisplay-content u-width-${content.width || 100}`}>
         {!!url && (
           <MediaPlayer
-            source={url}
+            sourceUrl={url}
             posterImageUrl={posterImageUrl}
             aspectRatio={content.aspectRatio}
             canDownload={canDownload}

--- a/src/styles/main.less
+++ b/src/styles/main.less
@@ -91,9 +91,11 @@
 @import '../components/pages/browser-not-supported.less';
 @import '../components/resource-picker/files-viewer.less';
 @import '../components/pages/complete-password-reset.less';
+@import '../components/media-player/plyr/media-player.less';
 @import '../components/media-player/media-player-track.less';
 @import '../components/admin/technical-maintenance-tab.less';
 @import '../components/external-account-provider-dialog.less';
+@import '../components/media-player/plyr/media-playback.less';
 @import '../components/resource-picker/resource-preview.less';
 @import '../components/media-player/media-volume-slider.less';
 @import '../components/resource-picker/storage-location.less';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2830,6 +2830,11 @@ copy-to-clipboard@^3.2.0:
   dependencies:
     toggle-selection "^1.0.6"
 
+core-js@^3.26.1:
+  version "3.27.0"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.27.0.tgz#a343bc614f29d9dcffa7616e65e10f9001cdd332"
+  integrity sha512-wY6cKosevs430KRkHUIsvepDXHGjlXOZO3hYXNyqpD6JvB0X28aXyv0t1Y1vZMwE7SoKmtfa6IASHCPN52FwBQ==
+
 core-util-is@1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
@@ -2938,6 +2943,11 @@ csstype@^3.0.10, csstype@^3.0.2:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.1.1.tgz#841b532c45c758ee546a11d5bd7b7b473c8c30b9"
   integrity sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw==
+
+custom-event-polyfill@^1.0.7:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/custom-event-polyfill/-/custom-event-polyfill-1.0.7.tgz#9bc993ddda937c1a30ccd335614c6c58c4f87aee"
+  integrity sha512-TDDkd5DkaZxZFM8p+1I3yAlvM3rSr1wbrOliG4yJiwinMZN8z/iGL7BTlDkrJcYTmgUSb4ywVCc3ZaUtOtC76w==
 
 d@1, d@^1.0.1:
   version "1.0.1"
@@ -5762,6 +5772,11 @@ load-script@^1.0.0:
   resolved "https://registry.yarnpkg.com/load-script/-/load-script-1.0.0.tgz#0491939e0bee5643ee494a7e3da3d2bac70c6ca4"
   integrity sha512-kPEjMFtZvwL9TaZo0uZ2ml+Ye9HUMmPwbYRJ324qF9tqMejwykJ5ggTyvzmrbBeapCAbk98BSbTeovHEEP1uCA==
 
+loadjs@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/loadjs/-/loadjs-4.2.0.tgz#2a0336376397a6a43edf98c9ec3229ddd5abb6f6"
+  integrity sha512-AgQGZisAlTPbTEzrHPb6q+NYBMD+DP9uvGSIjSUM5uG+0jG15cb8axWpxuOIqrmQjn6scaaH8JwloiP27b2KXA==
+
 local-pkg@^0.4.2:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/local-pkg/-/local-pkg-0.4.2.tgz#13107310b77e74a0e513147a131a2ba288176c2f"
@@ -7104,6 +7119,17 @@ pinkie@^2.0.0:
   resolved "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870"
   integrity sha512-MnUuEycAemtSaeFSjXKW/aroV7akBbY+Sv+RkyqFjgAe73F+MR0TBWKBRDkmfWq/HiFmdavfZ1G7h4SPZXaCSg==
 
+plyr@^3.7.3:
+  version "3.7.3"
+  resolved "https://registry.yarnpkg.com/plyr/-/plyr-3.7.3.tgz#31465bb45dc910babed5f05f4cf2667604898fa5"
+  integrity sha512-ORULENBvEvvzMYXRQBALDmEi8P+wZt1Hr/NvHqchu/t7E2xJKNkRYWx0qCA1HETIGZ6zobrOVgqeAUqWimS7fQ==
+  dependencies:
+    core-js "^3.26.1"
+    custom-event-polyfill "^1.0.7"
+    loadjs "^4.2.0"
+    rangetouch "^2.0.1"
+    url-polyfill "^1.1.12"
+
 pony-cause@^2.1.2:
   version "2.1.8"
   resolved "https://registry.yarnpkg.com/pony-cause/-/pony-cause-2.1.8.tgz#85d5c108566c63e81c6539a2f711598594543e4d"
@@ -7340,6 +7366,11 @@ range-parser@^1.2.0, range-parser@~1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.1.tgz#3cf37023d199e1c24d1a55b84800c2f3e6468031"
   integrity sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==
+
+rangetouch@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/rangetouch/-/rangetouch-2.0.1.tgz#c01105110fd3afca2adcb1a580692837d883cb70"
+  integrity sha512-sln+pNSc8NGaHoLzwNBssFSf/rSYkqeBXzX1AtJlkJiUaVSJSbRAWJk+4omsXkN+EJalzkZhWQ3th1m0FpR5xA==
 
 raw-body@2.5.1:
   version "2.5.1"
@@ -9384,6 +9415,11 @@ urix@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
   integrity sha512-Am1ousAhSLBeB9cG/7k7r2R0zj50uDRlZHPGbazid5s9rlF1F/QKYObEKSIunSjIOkJZqwRRLpvewjEkM7pSqg==
+
+url-polyfill@^1.1.12:
+  version "1.1.12"
+  resolved "https://registry.yarnpkg.com/url-polyfill/-/url-polyfill-1.1.12.tgz#6cdaa17f6b022841b3aec0bf8dbd87ac0cd33331"
+  integrity sha512-mYFmBHCapZjtcNHW0MDq9967t+z4Dmg5CJ0KqysK3+ZbyoNOWQHksGCTWwDhxGXllkWlOc10Xfko6v4a3ucM6A==
 
 url-template@~2.0.6:
   version "2.0.8"


### PR DESCRIPTION
Closes https://educandu.atlassian.net/browse/EDU-1002

This library also has a few glitches that I have corrected or that we might need to correct (or live with). So far though it seems to be less of a black box compared to `react-player` and the play/pause toggle seems to be reliable.
Also, all videos can now be played/paused by clicking on the video itself, so we would have consistency between youtube and CDN resources.