### PR TITLE
EDU-1049 Show multitrack as loading until all tracks are ready

### DIFF
--- a/src/components/media-player/multitrack-media-player.less
+++ b/src/components/media-player/multitrack-media-player.less
@@ -1,5 +1,13 @@
 .MultitrackMediaPlayer {}
 
+.MultitrackMediaPlayer-loadingOverlay {
+  .m-mask;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: fade(@edu-background-color-light, 60%);
+}
+
 .MultitrackMediaPlayer-errorMessage {
   text-align: center;
   color: @edu-error-color;


### PR DESCRIPTION
Closes https://educandu.atlassian.net/browse/EDU-1049

<img width="335" alt="Screen Shot 2023-01-20 at 10 03 05" src="https://user-images.githubusercontent.com/8189923/213656955-8242f25e-d6d9-4c4f-be94-33deabb2f5f0.png">
<img width="339" alt="Screen Shot 2023-01-20 at 10 04 07" src="https://user-images.githubusercontent.com/8189923/213656964-83784b9f-2607-4b18-b36e-61bfe977d035.png">
