### PR TITLE
EDU-1055 Add width to markdown-with-image plugin

### DIFF
--- a/migrations/educandu-2023-01-26-01-add-width-to-markdown-with-image-plugin.js
+++ b/migrations/educandu-2023-01-26-01-add-width-to-markdown-with-image-plugin.js
@@ -1,0 +1,59 @@
+export default class Educandu_2023_01_26_01_add_width_to_markdown_with_image_plugin {
+  constructor(db) {
+    this.db = db;
+  }
+
+  async collectionUp(collectionName) {
+    const result = await this.db.collection(collectionName).updateMany(
+      {},
+      {
+        $set: {
+          'sections.$[sectionElement].content.width': 100
+        }
+      },
+      {
+        arrayFilters: [
+          {
+            'sectionElement.type': 'markdown-with-image',
+            'sectionElement.content': { $ne: null }
+          }
+        ],
+        multi: true
+      }
+    );
+
+    console.log(`Updated ${collectionName}: ${JSON.stringify(result)}`);
+  }
+
+  async collectionDown(collectionName) {
+    const result = await this.db.collection(collectionName).updateMany(
+      {},
+      {
+        $unset: {
+          'sections.$[sectionElement].content.width': null
+        }
+      },
+      {
+        arrayFilters: [
+          {
+            'sectionElement.type': 'markdown-with-image',
+            'sectionElement.content': { $ne: null }
+          }
+        ],
+        multi: true
+      }
+    );
+
+    console.log(`Updated ${collectionName}: ${JSON.stringify(result)}`);
+  }
+
+  async up() {
+    await this.collectionUp('documents');
+    await this.collectionUp('documentRevisions');
+  }
+
+  async down() {
+    await this.collectionDown('documents');
+    await this.collectionDown('documentRevisions');
+  }
+}

--- a/src/plugins/markdown-with-image/markdown-with-image-display.js
+++ b/src/plugins/markdown-with-image/markdown-with-image-display.js
@@ -10,7 +10,7 @@ import { sectionDisplayProps } from '../../ui/default-prop-types.js';
 
 export default function MarkdownWithImageDisplay({ content }) {
   const clientConfig = useService(ClientConfig);
-  const { text, textOffsetInEm, image } = content;
+  const { text, textOffsetInEm, width, image } = content;
 
   const imageSrc = getAccessibleUrl({ url: image.sourceUrl, cdnRootUrl: clientConfig.cdnRootUrl });
 
@@ -22,7 +22,7 @@ export default function MarkdownWithImageDisplay({ content }) {
   );
 
   return (
-    <div className="MarkdownWithImageDisplay">
+    <div className={`MarkdownWithImageDisplay u-horizontally-centered u-width-${width}`}>
       <div className={imageWrapperClasses}>
         <img src={imageSrc} className="MarkdownWithImageDisplay-image" />
         {!!image.copyrightNotice && <CopyrightNotice value={image.copyrightNotice} />}

--- a/src/plugins/markdown-with-image/markdown-with-image-editor.js
+++ b/src/plugins/markdown-with-image/markdown-with-image-editor.js
@@ -25,7 +25,7 @@ export default function MarkdownWithImageEditor({ content, onContentChanged }) {
   const { t } = useTranslation('markdownWithImage');
   const emFormatter = useNumberWithUnitFormat({ unit: 'em' });
 
-  const { text, textOffsetInEm, image } = content;
+  const { text, textOffsetInEm, width, image } = content;
 
   const changeContent = newContentValues => {
     const newContent = { ...content, ...newContentValues };
@@ -42,6 +42,10 @@ export default function MarkdownWithImageEditor({ content, onContentChanged }) {
 
   const handleTextOffsetInEmChange = value => {
     changeContent({ textOffsetInEm: value });
+  };
+
+  const handleWidthChange = value => {
+    changeContent({ width: value });
   };
 
   const handleImageSourceUrlChange = value => {
@@ -95,18 +99,25 @@ export default function MarkdownWithImageEditor({ content, onContentChanged }) {
         <Form.Item label={t('common:copyrightNotice')} {...FORM_ITEM_LAYOUT}>
           <MarkdownInput value={image.copyrightNotice} onChange={handleImageCopyrightNoticeChange} />
         </Form.Item>
-        <FormItem
-          className="ImageEditor-widthInput"
-          label={<Info tooltip={t('common:widthInfo')}>{t('common:width')}</Info>}
-          {...FORM_ITEM_LAYOUT}
-          >
-          <ObjectWidthSlider value={image.width} onChange={handleImageWidthChange} />
-        </FormItem>
         <FormItem label={t('imagePosition')} {...FORM_ITEM_LAYOUT}>
           <RadioGroup value={image.position} onChange={handleImagePositionChange}>
             <RadioButton value={IMAGE_POSITION.left}>{t('left')}</RadioButton>
             <RadioButton value={IMAGE_POSITION.right}>{t('right')}</RadioButton>
           </RadioGroup>
+        </FormItem>
+        <FormItem
+          className="ImageEditor-widthInput"
+          label={<Info tooltip={t('imageWidthInfo')}>{t('imageWidth')}</Info>}
+          {...FORM_ITEM_LAYOUT}
+          >
+          <ObjectWidthSlider value={image.width} onChange={handleImageWidthChange} />
+        </FormItem>
+        <FormItem
+          className="ImageEditor-widthInput"
+          label={<Info tooltip={t('common:widthInfo')}>{t('common:width')}</Info>}
+          {...FORM_ITEM_LAYOUT}
+          >
+          <ObjectWidthSlider value={width} onChange={handleWidthChange} />
         </FormItem>
       </Form>
     </div>

--- a/src/plugins/markdown-with-image/markdown-with-image-info.js
+++ b/src/plugins/markdown-with-image/markdown-with-image-info.js
@@ -37,6 +37,7 @@ class MarkdownWithImageInfo {
     return {
       text: '',
       textOffsetInEm: 0,
+      width: 100,
       image: {
         sourceUrl: '',
         width: 50,
@@ -50,6 +51,7 @@ class MarkdownWithImageInfo {
     const schema = joi.object({
       text: joi.string().allow('').required(),
       textOffsetInEm: joi.number().min(0).max(2).required(),
+      width: joi.number().min(0).max(100).required(),
       image: joi.object({
         sourceUrl: joi.string().allow('').required(),
         width: joi.number().min(0).max(100).required(),

--- a/src/plugins/markdown-with-image/markdown-with-image.yml
+++ b/src/plugins/markdown-with-image/markdown-with-image.yml
@@ -15,7 +15,7 @@ imageWidth:
   de: Bildbreite
 imageWidthInfo:
   en: Represents the width taken by the image, from the total allocated space
-  de: Represents the width taken by the image, from the total allocated space [but in German]
+  de: Repräsentiert die Breite, die das Bild einnimmt, gemessen an der Gesamtbreite des Abschnitts
 imagePosition:
   en: Image position
   de: Bildstelle

--- a/src/plugins/markdown-with-image/markdown-with-image.yml
+++ b/src/plugins/markdown-with-image/markdown-with-image.yml
@@ -13,6 +13,9 @@ imageUrl:
 imageWidth:
   en: Image width
   de: Bildbreite
+imageWidthInfo:
+  en: Represents the width taken by the image, from the total allocated space
+  de: Represents the width taken by the image, from the total allocated space [but in German]
 imagePosition:
   en: Image position
   de: Bildstelle

--- a/src/resources/resources.json
+++ b/src/resources/resources.json
@@ -2084,6 +2084,7 @@
       "textOffsetInfo": "1em corresponds to the current paragraph font size",
       "imageUrl": "Image URL",
       "imageWidth": "Image width",
+      "imageWidthInfo": "Represents the width taken by the image, from the total allocated space",
       "imagePosition": "Image position",
       "left": "left",
       "right": "right"
@@ -2098,6 +2099,7 @@
       "textOffsetInfo": "1 em entspricht der verwendeten Absatz-Schriftgröße",
       "imageUrl": "Bild-URL",
       "imageWidth": "Bildbreite",
+      "imageWidthInfo": "Represents the width taken by the image, from the total allocated space [but in German]",
       "imagePosition": "Bildstelle",
       "left": "Links",
       "right": "Rechts"

--- a/src/resources/resources.json
+++ b/src/resources/resources.json
@@ -2099,7 +2099,7 @@
       "textOffsetInfo": "1 em entspricht der verwendeten Absatz-Schriftgröße",
       "imageUrl": "Bild-URL",
       "imageWidth": "Bildbreite",
-      "imageWidthInfo": "Represents the width taken by the image, from the total allocated space [but in German]",
+      "imageWidthInfo": "Repräsentiert die Breite, die das Bild einnimmt, gemessen an der Gesamtbreite des Abschnitts",
       "imagePosition": "Bildstelle",
       "left": "Links",
       "right": "Rechts"


### PR DESCRIPTION
Closes https://educandu.atlassian.net/browse/EDU-1055

<img width="1209" alt="Screen Shot 2023-01-26 at 19 38 23" src="https://user-images.githubusercontent.com/8189923/214921456-524f761e-212b-4248-934f-aef670101545.png">
<img width="1206" alt="Screen Shot 2023-01-26 at 19 38 35" src="https://user-images.githubusercontent.com/8189923/214921472-27eb46fb-09a9-45bb-9228-f79a2d25519f.png">
