### PR TITLE
EDU-1084 Map userId of room invitation into client data, for room invitation cards on dashboard

### DIFF
--- a/src/services/client-data-mapping-service.js
+++ b/src/services/client-data-mapping-service.js
@@ -165,6 +165,7 @@ class ClientDataMappingService {
         name: room.name,
         documentsMode: room.documentsMode,
         owner: {
+          _id: owner._id,
           displayName: owner.displayName
         }
       }

--- a/src/services/client-data-mapping-service.spec.js
+++ b/src/services/client-data-mapping-service.spec.js
@@ -431,6 +431,7 @@ describe('client-data-mapping-service', () => {
           name: room.name,
           documentsMode: room.documentsMode,
           owner: {
+            _id: user1._id,
             displayName: user1.displayName
           }
         }


### PR DESCRIPTION
Closes https://educandu.atlassian.net/browse/EDU-1084

For a little visual context, it's about the link to the profile page of the owner of the room the current user was invited to:


<img width="565" alt="Screen Shot 2023-01-30 at 10 49 11" src="https://user-images.githubusercontent.com/8189923/215444089-f3b350d7-9717-4d37-8d34-81a2b3cbb23f.png">
