### PR TITLE
EDU-1119 Change external link source input to url-input in catalog plugin

### DIFF
--- a/migrations/educandu-2023-02-13-01-rename-source-types-in-catalog-plugin-items.js
+++ b/migrations/educandu-2023-02-13-01-rename-source-types-in-catalog-plugin-items.js
@@ -1,0 +1,73 @@
+export default class Educandu_2023_02_13_01_rename_source_types_in_catalog_plugin_items {
+  constructor(db) {
+    this.db = db;
+  }
+
+  async collectionUp(collectionName) {
+    const cursor = this.db.collection(collectionName).find({ 'sections.type': 'catalog' });
+
+    while (await cursor.hasNext()) {
+      const doc = await cursor.next();
+
+      let isUpdated = false;
+      for (const section of doc.sections) {
+        if (section.type === 'catalog' && !!section.content) {
+          for (const item of section.content.items) {
+            if (item.link.sourceType === 'external') {
+              item.link.sourceType = 'sourceUrl';
+              isUpdated = true;
+            }
+            if (item.link.sourceType === 'document') {
+              item.link.sourceType = 'documentId';
+              isUpdated = true;
+            }
+          }
+        }
+      }
+
+      if (isUpdated) {
+        await this.db.collection(collectionName).replaceOne({ _id: doc._id }, doc);
+        console.log(`Updated ${collectionName} - ${doc._id}`);
+      }
+    }
+  }
+
+  async collectionDown(collectionName) {
+    const cursor = this.db.collection(collectionName).find({ 'sections.type': 'catalog' });
+
+    while (await cursor.hasNext()) {
+      const doc = await cursor.next();
+
+      let isUpdated = false;
+      for (const section of doc.sections) {
+        if (section.type === 'catalog' && !!section.content) {
+          for (const item of section.content.items) {
+            if (item.link.sourceType === 'sourceUrl') {
+              item.link.sourceType = 'external';
+              isUpdated = true;
+            }
+            if (item.link.sourceType === 'documentId') {
+              item.link.sourceType = 'document';
+              isUpdated = true;
+            }
+          }
+        }
+      }
+
+      if (isUpdated) {
+        await this.db.collection(collectionName).replaceOne({ _id: doc._id }, doc);
+        console.log(`Updated ${collectionName} - ${doc._id}`);
+      }
+    }
+  }
+
+  async up() {
+    await this.collectionUp('documents');
+    await this.collectionUp('documentRevisions');
+  }
+
+  async down() {
+    await this.collectionDown('documents');
+    await this.collectionDown('documentRevisions');
+  }
+}

--- a/src/plugins/catalog/catalog-display.js
+++ b/src/plugins/catalog/catalog-display.js
@@ -13,9 +13,9 @@ import { TILES_HOVER_EFFECT, LINK_SOURCE_TYPE, DISPLAY_MODE } from './constants.
 const getItemLinkUrl = ({ item, cdnRootUrl }) => {
   const link = item.link || {};
   switch (link.sourceType) {
-    case LINK_SOURCE_TYPE.external:
+    case LINK_SOURCE_TYPE.sourceUrl:
       return getAccessibleUrl({ url: link.sourceUrl, cdnRootUrl });
-    case LINK_SOURCE_TYPE.document:
+    case LINK_SOURCE_TYPE.documentId:
       return link.documentId ? routes.getDocUrl({ id: link.documentId }) : '';
     default:
       return '';

--- a/src/plugins/catalog/catalog-info.spec.js
+++ b/src/plugins/catalog/catalog-info.spec.js
@@ -8,22 +8,22 @@ describe('catalog-info', () => {
   });
 
   describe('getCdnResources', () => {
-    it('returns empty list for an external resource', () => {
+    it('returns empty list for an image with an external URL', () => {
       const result = sut.getCdnResources({ items: [{ image: { sourceUrl: 'https://someplace.com/image.png' } }] });
       expect(result).toHaveLength(0);
     });
 
-    it('returns empty list for an internal resource without url', () => {
+    it('returns empty list for an image without url', () => {
       const result = sut.getCdnResources({ items: [{ image: { sourceUrl: null } }] });
       expect(result).toHaveLength(0);
     });
 
-    it('returns a list with the url for an internal resource', () => {
+    it('returns a list with the url for an image with an internal URL', () => {
       const result = sut.getCdnResources({ items: [{ image: { sourceUrl: 'cdn://document-media/some-image.png' } }] });
       expect(result).toEqual(['cdn://document-media/some-image.png']);
     });
 
-    it('returns a list with all urls for all internal resources', () => {
+    it('returns a list with all internal URLs', () => {
       const result = sut.getCdnResources({
         items: [
           { image: { sourceUrl: 'cdn://document-media/12345/some-image-1.png' } },

--- a/src/plugins/catalog/catalog-item-editor.js
+++ b/src/plugins/catalog/catalog-item-editor.js
@@ -1,8 +1,8 @@
 import PropTypes from 'prop-types';
+import { Button, Form, Radio } from 'antd';
 import { useTranslation } from 'react-i18next';
 import { LINK_SOURCE_TYPE } from './constants.js';
 import React, { Fragment, useState } from 'react';
-import { Button, Form, Input, Radio } from 'antd';
 import UrlInput from '../../components/url-input.js';
 import { ensureIsExcluded } from '../../utils/array-utils.js';
 import MarkdownInput from '../../components/markdown-input.js';
@@ -36,11 +36,11 @@ function CatalogItemEditor({ item, enableImageEditing, onChange }) {
     triggerChange({ link: { ...link, sourceType: event.target.value, sourceUrl: '', documentId: null } });
   };
 
-  const handleExternalLinkUrlValueChange = event => {
-    triggerChange({ link: { ...link, sourceUrl: event.target.value, documentId: null } });
+  const handleLinkSourceUrlChange = value => {
+    triggerChange({ link: { ...link, sourceUrl: value, documentId: null } });
   };
 
-  const handleDocumentChange = value => {
+  const handleLinkDocumentIdChange = value => {
     triggerChange({ link: { ...link, sourceUrl: '', documentId: value } });
   };
 
@@ -63,27 +63,23 @@ function CatalogItemEditor({ item, enableImageEditing, onChange }) {
       <FormItem label={t('common:title')} {...FORM_ITEM_LAYOUT}>
         <MarkdownInput inline value={title} onChange={handleTitleChange} />
       </FormItem>
-      <FormItem label={t('linkSource')} {...FORM_ITEM_LAYOUT}>
+      <FormItem label={t('linkSourceType')} {...FORM_ITEM_LAYOUT}>
         <RadioGroup value={link.sourceType} onChange={handleLinkSourceTypeChange}>
-          <RadioButton value={LINK_SOURCE_TYPE.document}>{t('documentLink')}</RadioButton>
-          <RadioButton value={LINK_SOURCE_TYPE.external}>{t('externalLink')}</RadioButton>
+          <RadioButton value={LINK_SOURCE_TYPE.documentId}>{t('documentLink')}</RadioButton>
+          <RadioButton value={LINK_SOURCE_TYPE.sourceUrl}>{t('link')}</RadioButton>
         </RadioGroup>
       </FormItem>
-      {link.sourceType === LINK_SOURCE_TYPE.external && (
-        <FormItem
-          label={t('catalog:externalUrl')}
-          {...FORM_ITEM_LAYOUT}
-          hasFeedback
-          >
-          <Input value={link.sourceUrl} onChange={handleExternalLinkUrlValueChange} />
+      {link.sourceType === LINK_SOURCE_TYPE.sourceUrl && (
+        <FormItem label={t('linkSource')} {...FORM_ITEM_LAYOUT}>
+          <UrlInput value={link.sourceUrl} onChange={handleLinkSourceUrlChange} />
         </FormItem>
       )}
-      {link.sourceType === LINK_SOURCE_TYPE.document && (
+      {link.sourceType === LINK_SOURCE_TYPE.documentId && (
         <FormItem label={t('common:document')} {...FORM_ITEM_LAYOUT}>
           <div className="u-input-and-button">
             <DocumentSelector
               documentId={link.documentId}
-              onChange={handleDocumentChange}
+              onChange={handleLinkDocumentIdChange}
               onTitleChange={handleDocumentTitleChange}
               />
             <Button

--- a/src/plugins/catalog/catalog-utils.js
+++ b/src/plugins/catalog/catalog-utils.js
@@ -15,7 +15,7 @@ export function createDefaultItem() {
     title: '',
     image: createDefaultItemImage(),
     link: {
-      sourceType: LINK_SOURCE_TYPE.document,
+      sourceType: LINK_SOURCE_TYPE.documentId,
       sourceUrl: '',
       documentId: null,
       description: ''

--- a/src/plugins/catalog/catalog.less
+++ b/src/plugins/catalog/catalog.less
@@ -21,7 +21,7 @@
   font-size: @edu-font-size-sm;
   color: @edu-text-color-secondary;
 
-  &.CatalogDisplay-itemLinkDescription--centered {
+  .CatalogDisplay-itemLinkDescription--centered {
     text-align: center;
   }
 }

--- a/src/plugins/catalog/catalog.yml
+++ b/src/plugins/catalog/catalog.yml
@@ -18,10 +18,10 @@ catalog:
     en: Hover effect
     de: Hover-Effekt
   hoverEffect_none:
-    en: No effect
+    en: no effect
     de: Kein Effekt
   hoverEffect_colorizeZoom:
-    en: Color and zoom
+    en: color and zoom
     de: Färben und Zoomen
   itemNumber:
     en: Item {number}
@@ -29,18 +29,18 @@ catalog:
   addItem:
     en: Add item
     de: Eintrag hinzufügen
-  linkSource:
-    en: Link type
-    de: Link-Typ
+  linkSourceType:
+    en: Item type
+    de: Eintragstyp
   documentLink:
     en: document link
     de: Dokument-Link
-  externalLink:
-    en: external link
-    de: Externer Link
-  externalUrl:
-    en: External URL
-    de: Externe URL
+  link:
+    en: link
+    de: Link
+  linkSource:
+    en: Link source
+    de: Link-Quelle
   adoptDocumentTitle:
     en: Use as title
     de: Als Titel benutzen

--- a/src/plugins/catalog/constants.js
+++ b/src/plugins/catalog/constants.js
@@ -4,8 +4,8 @@ export const DISPLAY_MODE = {
 };
 
 export const LINK_SOURCE_TYPE = {
-  external: 'external',
-  document: 'document'
+  sourceUrl: 'sourceUrl',
+  documentId: 'documentId'
 };
 
 export const TILES_HOVER_EFFECT = {

--- a/src/plugins/iframe/iframe-editor.js
+++ b/src/plugins/iframe/iframe-editor.js
@@ -42,11 +42,7 @@ function IframeEditor({ content, onContentChanged }) {
   return (
     <div>
       <Form layout="horizontal" labelAlign="left">
-        <FormItem
-          {...FORM_ITEM_LAYOUT}
-          label={t('common:url')}
-          hasFeedback
-          >
+        <FormItem {...FORM_ITEM_LAYOUT} label={t('common:url')}>
           <Input value={url} onChange={handleExternalUrlValueChanged} />
         </FormItem>
         <Form.Item label={t('border')} {...FORM_ITEM_LAYOUT}>

--- a/src/resources/resources.json
+++ b/src/resources/resources.json
@@ -2069,11 +2069,11 @@
       "de": "Hover-Effekt"
     },
     "hoverEffect_none": {
-      "en": "No effect",
+      "en": "no effect",
       "de": "Kein Effekt"
     },
     "hoverEffect_colorizeZoom": {
-      "en": "Color and zoom",
+      "en": "color and zoom",
       "de": "Färben und Zoomen"
     },
     "itemNumber": {
@@ -2084,21 +2084,21 @@
       "en": "Add item",
       "de": "Eintrag hinzufügen"
     },
-    "linkSource": {
-      "en": "Link type",
-      "de": "Link-Typ"
+    "linkSourceType": {
+      "en": "Item type",
+      "de": "Eintragstyp"
     },
     "documentLink": {
       "en": "document link",
       "de": "Dokument-Link"
     },
-    "externalLink": {
-      "en": "external link",
-      "de": "Externer Link"
+    "link": {
+      "en": "link",
+      "de": "Link"
     },
-    "externalUrl": {
-      "en": "External URL",
-      "de": "Externe URL"
+    "linkSource": {
+      "en": "Link source",
+      "de": "Link-Quelle"
     },
     "adoptDocumentTitle": {
       "en": "Use as title",


### PR DESCRIPTION
Closes https://educandu.atlassian.net/browse/EDU-1119

Attaching picture with (German) translations to check if they make sense this way.

**Case 1: Link list**

<img width="1115" alt="Screen Shot 2023-02-13 at 16 44 41" src="https://user-images.githubusercontent.com/8189923/218504678-e03921d1-792e-458e-95a1-7c2f6d2c7fec.png">

----

**Case 2: Image tiles**

<img width="1115" alt="Screen Shot 2023-02-13 at 16 44 56" src="https://user-images.githubusercontent.com/8189923/218504728-3d8fae5d-75d1-47d9-8712-7d2e99f543ed.png">
