### PR TITLE
EDU-1129 Make panels draggable by their entire header

### DIFF
--- a/src/components/item-panel.js
+++ b/src/components/item-panel.js
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { useTranslation } from 'react-i18next';
-import { DragOutlined } from '@ant-design/icons';
 import { Button, Collapse, Tooltip } from 'antd';
 import DeleteIcon from '../components/icons/general/delete-icon.js';
 import MoveUpIcon from '../components/icons/general/move-up-icon.js';
@@ -48,14 +47,6 @@ function ItemPanel({
   };
 
   const actionButtons = [];
-  if (dragHandleProps) {
-    actionButtons.push({
-      key: 'dragHandle',
-      title: t('common:dragToReorder'),
-      icon: <div {...dragHandleProps}><DragOutlined /></div>,
-      disabled: itemsCount === 1
-    });
-  }
   if (onMoveUp) {
     actionButtons.push({
       key: 'moveUp',
@@ -110,10 +101,10 @@ function ItemPanel({
   };
 
   return (
-    <Collapse className={classNames('ItemPanel', { 'is-dragged': isDragged, 'is-other-dragged': isOtherDragged })} defaultActiveKey="panel">
+    <Collapse collapsible="icon" className={classNames('ItemPanel', { 'is-dragged': isDragged, 'is-other-dragged': isOtherDragged })} defaultActiveKey="panel">
       <Collapse.Panel
         key="panel"
-        header={<div className="ItemPanel-header">{header}</div>}
+        header={<div {...dragHandleProps} className="ItemPanel-header">{header}</div>}
         extra={renderActionButtons()}
         >
         <div className="ItemPanel-contentWrapper">

--- a/src/components/pages/room.js
+++ b/src/components/pages/room.js
@@ -9,13 +9,13 @@ import { useUser } from '../user-context.js';
 import FavoriteStar from '../favorite-star.js';
 import DeleteButton from '../delete-button.js';
 import { useTranslation } from 'react-i18next';
+import { MailOutlined } from '@ant-design/icons';
 import { useDateFormat } from '../locale-context.js';
 import RoomMetadataForm from '../room-metadata-form.js';
 import DeleteIcon from '../icons/general/delete-icon.js';
 import { handleApiError } from '../../ui/error-helper.js';
 import MoveUpIcon from '../icons/general/move-up-icon.js';
 import MoveDownIcon from '../icons/general/move-down-icon.js';
-import { DragOutlined, MailOutlined } from '@ant-design/icons';
 import DuplicateIcon from '../icons/general/duplicate-icon.js';
 import DragAndDropContainer from '../drag-and-drop-container.js';
 import RoomApiClient from '../../api-clients/room-api-client.js';
@@ -277,14 +277,8 @@ export default function Room({ PageTemplate, initialState }) {
     );
   };
 
-  const renderDocumentActionButtons = ({ doc, index, docsCount, dragHandleProps }) => {
+  const renderDocumentActionButtons = ({ doc, index, docsCount }) => {
     const actionButtons = [
-      {
-        key: 'dragHandle',
-        title: t('common:dragToReorder'),
-        icon: <div {...dragHandleProps}><DragOutlined /></div>,
-        disabled: doc.roomContext.draft || docsCount === 1
-      },
       {
         key: 'moveUp',
         title: t('common:moveUp'),
@@ -329,7 +323,7 @@ export default function Room({ PageTemplate, initialState }) {
     ));
   };
 
-  const renderDocumentWithActionButtons = ({ doc, actionButtons, isDragged, isOtherDragged }) => {
+  const renderDocumentWithActionButtons = ({ doc, actionButtons, dragHandleProps, isDragged, isOtherDragged }) => {
     const url = routes.getDocUrl({ id: doc._id, slug: doc.slug });
     const classes = classNames(
       'RoomPage-document',
@@ -339,7 +333,7 @@ export default function Room({ PageTemplate, initialState }) {
     );
 
     return (
-      <div key={doc._id} className={classes}>
+      <div key={doc._id} className={classes} {...dragHandleProps}>
         <div className="RoomPage-documentTitle">
           <a href={url}>{doc.title}</a>
         </div>
@@ -384,8 +378,8 @@ export default function Room({ PageTemplate, initialState }) {
     const draggableItems = nonDraftDocuments.map((doc, index) => ({
       key: doc._id,
       render: ({ dragHandleProps, isDragged, isOtherDragged }) => {
-        const actionButtons = renderDocumentActionButtons({ doc, index, docsCount, dragHandleProps });
-        return renderDocumentWithActionButtons({ doc, actionButtons, isDragged, isOtherDragged });
+        const actionButtons = renderDocumentActionButtons({ doc, index, docsCount });
+        return renderDocumentWithActionButtons({ doc, actionButtons, dragHandleProps, isDragged, isOtherDragged });
       }
     }));
 

--- a/src/resources/common.yml
+++ b/src/resources/common.yml
@@ -509,9 +509,6 @@ common:
   posterImageUrl:
     en: Preview image URL
     de: Vorschau-Bild-URL
-  dragToReorder:
-    en: Drag to reorder
-    de: Mit Drag&Drop verschieben
   browseFilesButtonLabel:
     en: Browse ...
     de: Durchsuchen ...

--- a/src/resources/resources.json
+++ b/src/resources/resources.json
@@ -3342,10 +3342,6 @@
       "en": "Preview image URL",
       "de": "Vorschau-Bild-URL"
     },
-    "dragToReorder": {
-      "en": "Drag to reorder",
-      "de": "Mit Drag&Drop verschieben"
-    },
     "browseFilesButtonLabel": {
       "en": "Browse ...",
       "de": "Durchsuchen ..."


### PR DESCRIPTION
Closes https://educandu.atlassian.net/browse/EDU-1129

**NOTE 1:** I will test this today in the evening on a Windows machine to test for any potential problems there.

**NOTE 2:** I removed the drag&drop help tooltip as it did not look good in most cases (it also would render very far from the mouse cursor in most cases).