### PR TITLE
EDU-1157 Correct data passed to media-player parts

### DIFF
--- a/src/plugins/interactive-media/interactive-media-display.js
+++ b/src/plugins/interactive-media/interactive-media-display.js
@@ -29,9 +29,7 @@ function InteractiveMediaDisplay({ content }) {
   const [interactingChapterIndex, setInteractingChapterIndex] = useState(-1);
   const [selectedAnswerPerChapter, setSelectedAnswerPerChapter] = useState(chapters.map(() => -1));
 
-  const parts = useMemo(() => chapters.map(chapter => ({
-    startPosition: chapter.startPosition
-  })), [chapters]);
+  const playerParts = useMemo(() => chapters.map(chapter => ({ startPosition: chapter.startPosition })), [chapters]);
 
   const chapterCards = useMemo(() => chapters.map((chapter, index) => ({
     label: (index + 1).toString(),
@@ -144,7 +142,7 @@ function InteractiveMediaDisplay({ content }) {
           customScreenOverlay={renderInteractionOverlay()}
           initialVolume={initialVolume}
           mediaPlayerRef={mediaPlayerRef}
-          parts={parts}
+          parts={playerParts}
           playbackRange={playbackRange}
           posterImageUrl={getAccessibleUrl({ url: posterImage.sourceUrl, cdnRootUrl: clientConfig.cdnRootUrl })}
           screenMode={showVideo ? MEDIA_SCREEN_MODE.video : MEDIA_SCREEN_MODE.audio}

--- a/src/plugins/interactive-media/interactive-media-editor.js
+++ b/src/plugins/interactive-media/interactive-media-editor.js
@@ -44,6 +44,7 @@ function InteractiveMediaEditor({ content, onContentChanged }) {
   const sourceDuration = mediaDuration.duration;
 
   const playbackDuration = (playbackRange[1] - playbackRange[0]) * sourceDuration;
+  const playerParts = useMemo(() => chapters.map(chapter => ({ startPosition: chapter.startPosition })), [chapters]);
 
   const selectedChapterStartTimecode = useMemo(
     () => chapters[selectedChapterIndex].startPosition * playbackDuration,
@@ -238,7 +239,7 @@ function InteractiveMediaEditor({ content, onContentChanged }) {
             <MediaPlayer
               allowPartClick
               aspectRatio={aspectRatio}
-              parts={chapters}
+              parts={playerParts}
               playbackRange={playbackRange}
               posterImageUrl={getAccessibleUrl({ url: posterImage.sourceUrl, cdnRootUrl: clientConfig.cdnRootUrl })}
               screenWidth={50}

--- a/src/plugins/media-slideshow/media-slideshow-display.js
+++ b/src/plugins/media-slideshow/media-slideshow-display.js
@@ -2,10 +2,10 @@ import { CHAPTER_TYPE } from './constants.js';
 import { cssUrl } from '../../utils/css-utils.js';
 import Markdown from '../../components/markdown.js';
 import { preloadImage } from '../../utils/image-utils.js';
-import React, { useEffect, useRef, useState } from 'react';
 import ClientConfig from '../../bootstrap/client-config.js';
 import { useService } from '../../components/container-context.js';
 import CopyrightNotice from '../../components/copyright-notice.js';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { sectionDisplayProps } from '../../ui/default-prop-types.js';
 import MediaPlayer from '../../components/media-player/media-player.js';
 import { MEDIA_ASPECT_RATIO, MEDIA_SCREEN_MODE } from '../../domain/constants.js';
@@ -19,6 +19,7 @@ function MediaSlideshowDisplay({ content }) {
   const [playingChapterIndex, setPlayingChapterIndex] = useState(0);
 
   const sourceUrl = getAccessibleUrl({ url: content.sourceUrl, cdnRootUrl: clientConfig.cdnRootUrl });
+  const playerParts = useMemo(() => chapters.map(chapter => ({ startPosition: chapter.startPosition })), [chapters]);
 
   useEffect(() => {
     (async () => {
@@ -76,7 +77,7 @@ function MediaSlideshowDisplay({ content }) {
           customScreenOverlay={renderPlayingChapter()}
           initialVolume={initialVolume}
           mediaPlayerRef={mediaPlayerRef}
-          parts={chapters}
+          parts={playerParts}
           playbackRange={playbackRange}
           screenMode={MEDIA_SCREEN_MODE.audio}
           sourceUrl={sourceUrl}

--- a/src/plugins/media-slideshow/media-slideshow-editor.js
+++ b/src/plugins/media-slideshow/media-slideshow-editor.js
@@ -10,12 +10,12 @@ import ItemPanel from '../../components/item-panel.js';
 import { CHAPTER_TYPE, IMAGE_FIT } from './constants.js';
 import MediaSlideshowInfo from './media-slideshow-info.js';
 import ClientConfig from '../../bootstrap/client-config.js';
-import React, { Fragment, useEffect, useState } from 'react';
 import MarkdownInput from '../../components/markdown-input.js';
 import Timeline from '../../components/media-player/timeline.js';
 import { formatMediaPosition } from '../../utils/media-utils.js';
 import { useService } from '../../components/container-context.js';
 import { sectionEditorProps } from '../../ui/default-prop-types.js';
+import React, { Fragment, useEffect, useMemo, useState } from 'react';
 import MediaPlayer from '../../components/media-player/media-player.js';
 import TrackEditor from '../../components/media-player/track-editor.js';
 import { usePercentageFormat } from '../../components/locale-context.js';
@@ -46,6 +46,11 @@ function MediaSlideshowEditor({ content, onContentChanged }) {
   const sourceDuration = mediaDuration.duration;
 
   const playbackDuration = (playbackRange[1] - playbackRange[0]) * sourceDuration;
+  const playerParts = useMemo(() => chapters.map(chapter => ({ startPosition: chapter.startPosition })), [chapters]);
+  const timelineParts = useMemo(() => chapters.map((chapter, index) => ({
+    ...chapter,
+    title: `${t('common:segment')} ${index + 1}`
+  })), [chapters, t]);
 
   useEffect(() => {
     const nextChapterStartPosition = chapters[selectedChapterIndex + 1]?.startPosition || 1;
@@ -164,11 +169,6 @@ function MediaSlideshowEditor({ content, onContentChanged }) {
     );
   };
 
-  const timelineParts = chapters.map((chapter, index) => ({
-    ...chapter,
-    title: `${t('common:segment')} ${index + 1}`
-  }));
-
   const allowedImageSourceTypes = ensureIsExcluded(Object.values(SOURCE_TYPE), SOURCE_TYPE.youtube);
 
   return (
@@ -197,7 +197,7 @@ function MediaSlideshowEditor({ content, onContentChanged }) {
             <div className="MediaSlideshowEditor-playerPreviewLabel">{t('common:preview')}</div>
             <MediaPlayer
               volume={initialVolume}
-              parts={chapters}
+              parts={playerParts}
               screenWidth={50}
               playbackRange={playbackRange}
               screenMode={MEDIA_SCREEN_MODE.audio}


### PR DESCRIPTION
Closes https://educandu.atlassian.net/browse/EDU-1157

For a bit of clarification:

The `media-player` - `parts` param gets passed to the progress bar, which either displays the timecode for each part, or the `text` of each part, when provided.

The `text` is something we use for the range selector, but we want the timecodes for the other cases. 
<img width="393" alt="Screen Shot 2023-02-20 at 09 57 29" src="https://user-images.githubusercontent.com/8189923/220059066-13b5ec59-6895-4e90-9574-62751ef510fd.png">

So we need to map the parts (which to be fair we should have done anyway) to exclude chapter text, otherwise it gets rendered instead of the timecode.

