### PR TITLE
EDU-1153 Fix progress bar tooltip flickering due to overlap of tooltip with the bar

### DIFF
--- a/src/components/media-player/media-player-progress-bar.less
+++ b/src/components/media-player/media-player-progress-bar.less
@@ -1,8 +1,6 @@
 @edu-progress-bar-height: 8px;
 @edu-progress-bar-vertical-padding: 1px;
-@edu-progress-bar-tooltip-text-height: 20px;
 @edu-progress-bar-tooltip-arrow-size: 5px;
-@edu-progress-bar-tooltip-height: @edu-progress-bar-tooltip-text-height + @edu-progress-bar-tooltip-arrow-size;
 @edu-progress-bar-hover-height: @edu-progress-bar-height + 2 * @edu-progress-bar-vertical-padding;
 
 .MediaPlayerProgressBar {
@@ -58,7 +56,7 @@
   justify-content: center;
   flex-direction: column;
   z-index: @edu-z-index-overlay-layer;
-  top: -@edu-progress-bar-tooltip-height - 10px;
+  top: -40px;
 }
 
 .MediaPlayerProgressBar-progressTooltipText {


### PR DESCRIPTION
Easily closes https://educandu.atlassian.net/browse/EDU-1153 with keeping the nice hover effect of the bar height changing.