### PR TITLE
EDU-1155 Fix room documents sorting hopefully for good

### DIFF
--- a/src/components/pages/room.less
+++ b/src/components/pages/room.less
@@ -65,6 +65,10 @@
     background-color: @edu-background-color-light;
   }
 
+  &.is-hidden {
+    display: none;
+  }
+
   &.is-other-dragged {
     opacity: 0.60;
 

--- a/src/server/room-controller.js
+++ b/src/server/room-controller.js
@@ -292,11 +292,7 @@ export default class RoomController {
       invitations = await this.roomService.getRoomInvitations(roomId);
     }
 
-    let documentsMetadata = await this.documentService.getDocumentsExtendedMetadataByIds(room.documents);
-
-    if (room.owner !== user._id) {
-      documentsMetadata = documentsMetadata.filter(doc => !doc.roomContext.draft);
-    }
+    const documentsMetadata = await this.documentService.getDocumentsExtendedMetadataByIds(room.documents);
 
     const mappedRoom = await this.clientDataMappingService.mapRoom({ room, viewingUser: user });
     const mappedDocumentsMetadata = await this.clientDataMappingService.mapDocsOrRevisions(documentsMetadata);

--- a/src/server/room-controller.spec.js
+++ b/src/server/room-controller.spec.js
@@ -718,7 +718,6 @@ describe('room-controller', () => {
       let documents;
       let viewingUser;
       let mappedInvitations;
-      let mappedNonDraftDocuments;
 
       beforeEach(async () => {
         viewingUser = { _id: 'member' };
@@ -731,7 +730,7 @@ describe('room-controller', () => {
           { _id: room.documents[0], roomContext: { draft: false } },
           { _id: room.documents[1], roomContext: { draft: true } }
         ];
-        mappedNonDraftDocuments = [cloneDeep(documents[0])];
+        mappedDocuments = cloneDeep(documents);
         mappedInvitations = [];
 
         roomService.getRoomById.resolves(room);
@@ -739,7 +738,7 @@ describe('room-controller', () => {
         documentService.getDocumentsExtendedMetadataByIds.resolves(documents);
 
         clientDataMappingService.mapRoom.resolves(mappedRoom);
-        clientDataMappingService.mapDocsOrRevisions.returns(mappedNonDraftDocuments);
+        clientDataMappingService.mapDocsOrRevisions.returns(mappedDocuments);
         clientDataMappingService.mapRoomInvitations.returns(mappedInvitations);
 
         await sut.handleGetRoomPage(request, {});
@@ -761,8 +760,8 @@ describe('room-controller', () => {
         assert.calledWith(documentService.getDocumentsExtendedMetadataByIds, room.documents);
       });
 
-      it('should call mapDocsOrRevisions with the non-draft documents returned by the service', () => {
-        assert.calledWith(clientDataMappingService.mapDocsOrRevisions, [documents[0]]);
+      it('should call mapDocsOrRevisions with the documents returned by the service', () => {
+        assert.calledWith(clientDataMappingService.mapDocsOrRevisions, documents);
       });
 
       it('should call pageRenderer with the right parameters', () => {
@@ -771,7 +770,7 @@ describe('room-controller', () => {
           request,
           {},
           PAGE_NAME.room,
-          { room: mappedRoom, documents: mappedNonDraftDocuments, invitations: mappedInvitations }
+          { room: mappedRoom, documents: mappedDocuments, invitations: mappedInvitations }
         );
       });
     });

--- a/src/services/room-service.spec.js
+++ b/src/services/room-service.spec.js
@@ -380,31 +380,13 @@ describe('room-service', () => {
       });
     });
 
-    describe('when the provided document ids is a reordered list of the ids of the non draft documents', () => {
-      beforeEach(async () => {
-        result = await sut.updateRoomDocumentsOrder(roomId, [document2._id, document1._id]);
-      });
-
-      it('should update the room documents order (having draft documents at the end)', () => {
-        expect(result.documents).toEqual([document2._id, document1._id, document3._id]);
-      });
-
-      it('should take a lock on the room', () => {
-        assert.calledWith(lockStore.takeRoomLock, roomId);
-      });
-
-      it('should release the lock on the room', () => {
-        assert.calledWith(lockStore.releaseLock, lock);
-      });
-    });
-
     describe('when the provided document ids is a reordered list of the ids of the draft and non draft documents', () => {
       beforeEach(async () => {
         result = await sut.updateRoomDocumentsOrder(roomId, [document3._id, document2._id, document1._id]);
       });
 
-      it('should update the room documents order (having draft documents at the end)', () => {
-        expect(result.documents).toEqual([document2._id, document1._id, document3._id]);
+      it('should update the room documents order', () => {
+        expect(result.documents).toEqual([document3._id, document2._id, document1._id]);
       });
 
       it('should take a lock on the room', () => {


### PR DESCRIPTION
Closes https://educandu.atlassian.net/browse/EDU-1155

**Explanation of the entangled situation**

For room documents there are 3 possible points of view:
1. owner (can see all documents, including drafts)
2. collaborator member, in "collaborative" rooms (can see only non-draft documents)
3. simple member, in "exclusive" rooms (can see only non-draft documents)

The complication comes for viewpoints 1. and 2., as they both can change the order of documents.

The previous solution:
- filtered out the non-draft documents on the server side, for viewpoints 2. and 3.
- **displayed** draft documents always at the end for viewpoint 1. and did not allow moving them
- whenever viewpoints 1. or 2. changed the documents order on client side, server side ensured draft documents were always at the end

This solution was spreading sorting knowledge and responsibility in several places, both on client and server side, which lead to edge cases and discrepancies.

Given that:
- the data of the draft documents provided to the room page is just metadata (content is excluded)
- the page is only accessible by a reduced set of users, room members
- navigation to a draft document page is protected on server side, reserved only to room owners
 
I considered it better to simplify the logic and ensure consistency by always providing all documents to the client side and simply not rendering the metadata for the draft ones.