### PR TITLE
AMB context URI Update

### DIFF
--- a/src/services/amb-service.js
+++ b/src/services/amb-service.js
@@ -9,7 +9,7 @@ import { extractUserIdsFromDocsOrRevisions } from '../domain/data-extractors.js'
 
 const defaultMetadata = {
   '@context': [
-    'https://w3id.org/kim/amb/draft/context.jsonld',
+    'https://w3id.org/kim/amb/context.jsonld',
     {
       '@language': 'de'
     }

--- a/src/services/amb-service.spec.js
+++ b/src/services/amb-service.spec.js
@@ -117,7 +117,7 @@ describe('amb-service', () => {
           expect(result).toEqual([
             {
               '@context': [
-                'https://w3id.org/kim/amb/draft/context.jsonld',
+                'https://w3id.org/kim/amb/context.jsonld',
                 {
                   '@language': 'de'
                 }
@@ -196,7 +196,7 @@ describe('amb-service', () => {
           expect(result).toEqual([
             {
               '@context': [
-                'https://w3id.org/kim/amb/draft/context.jsonld',
+                'https://w3id.org/kim/amb/context.jsonld',
                 {
                   '@language': 'de'
                 }


### PR DESCRIPTION
The context URI in amb was changed from `https://w3id.org/kim/amb/draft/context.jsonld` to `https://w3id.org/kim/amb/context.jsonld`

see also
* https://github.com/dini-ag-kim/amb/issues/167
* https://gitlab.com/oersi/oersi-schema/-/issues/3

With this PR the new context URI should be used. I hope I haven't missed anything.