### PR TITLE
EDU-1438 Fix cases that did not wrap in markdown-with-image (quote, video, audio)

### DIFF
--- a/src/components/markdown.less
+++ b/src/components/markdown.less
@@ -6,12 +6,11 @@
 
 .Markdown {
   blockquote {
-    display: block;
+    display: grid;
     background: @edu-white;
     padding: 15px 20px 15px 45px;
     margin: 40px 80px;
     position: relative;
-    clear: both;
     border-left: 15px solid @markdown-blockquote-color;
     border-right: 2px solid @markdown-blockquote-color;
     box-shadow: 2px 2px 15px @edu-border-color-base;
@@ -21,7 +20,7 @@
     }
   }
 
-  blockquote::before{
+  blockquote::before {
     content: "\201C";
     line-height: 60px;
     font-family: Georgia, serif;
@@ -30,10 +29,10 @@
     color: @markdown-blockquote-quotations-color;
     position: absolute;
     left: 10px;
-    top:5px;
+    top: 5px;
   }
 
-  blockquote::after{
+  blockquote::after {
     content: "";
   }
 
@@ -65,7 +64,9 @@
     font-weight: normal;
   }
 
-  ol, dl, ul {
+  ol,
+  dl,
+  ul {
     overflow: hidden;
     padding-left: 2.5em;
     list-style-position: outside;

--- a/src/plugins/markdown-with-image/markdown-with-image.less
+++ b/src/plugins/markdown-with-image/markdown-with-image.less
@@ -1,5 +1,12 @@
 .MarkdownWithImageDisplay {
   display: flow-root;
+
+  video,
+  audio {
+    display: grid;
+    min-width: 200px;
+    width: fill-available;
+  }
 }
 
 .MarkdownWithImageDisplay-imageWrapper {


### PR DESCRIPTION
Closes https://educandu.atlassian.net/browse/EDU-1428

Examples of the cases involved:

<img width="1060" alt="Screenshot 2023-11-08 at 16 03 26" src="https://github.com/educandu/educandu/assets/8189923/33c80376-694e-4906-a6b5-b863d2b7c2c9">
<img width="1029" alt="Screenshot 2023-11-08 at 16 03 37" src="https://github.com/educandu/educandu/assets/8189923/ce92592f-d830-4221-90dc-131bc4b77f9b">
<img width="1046" alt="Screenshot 2023-11-08 at 16 03 55" src="https://github.com/educandu/educandu/assets/8189923/71b37abb-6c91-449a-8c55-dc048cccb0f7">
<img width="1039" alt="Screenshot 2023-11-08 at 16 04 02" src="https://github.com/educandu/educandu/assets/8189923/6107fc27-bd89-40fe-a197-d7f7ab6e4888">
