### PR TITLE
EDU-1432 Fix duplicate keys in section content

### DIFF
--- a/migrations/educandu-2023-11-23-01-fix-unique-keys-in-section-contents.js
+++ b/migrations/educandu-2023-11-23-01-fix-unique-keys-in-section-contents.js
@@ -1,0 +1,127 @@
+import joi from 'joi';
+import { customAlphabet } from 'nanoid';
+
+const createUniqueId = customAlphabet('123456789abcdefghijkmnopqrstuvwxyzABCDEFGHJKLMNPQRSTUVWXYZ', 22);
+
+const validateKeysAreUnique = arrayToValidate => joi.attempt(
+  arrayToValidate,
+  joi.array().items(joi.object({ key: joi.string().required() })).unique('key'),
+  { abortEarly: false, convert: false, allowUnknown: true, noDefaults: true }
+);
+
+export default class Educandu_2023_11_23_01_fix_unique_keys_in_section_contents {
+  constructor(db) {
+    this.db = db;
+    this.replacementIds = Array.from({ length: 100 }, () => createUniqueId());
+  }
+
+  fixUniqueKeysInArray(items) {
+    let replacementIdIndex = 0;
+    let duplicateKeyFound = false;
+    const processedKeys = new Set();
+
+    for (const item of items) {
+      if (processedKeys.has(item.key)) {
+        item.key = this.replacementIds[replacementIdIndex];
+        duplicateKeyFound = true;
+        replacementIdIndex += 1;
+      }
+      processedKeys.add(item.key);
+    }
+
+    validateKeysAreUnique(items);
+    return duplicateKeyFound;
+  }
+
+  async collectionUp(collectionName) {
+    const sectionsToFix = [
+      {
+        type: 'catalog',
+        getArraysToFix: content => [content.items],
+        affectedSectionKeys: new Set(),
+        affectedDocumentIds: new Set()
+      },
+      {
+        type: 'ear-training',
+        getArraysToFix: content => [content.tests],
+        affectedSectionKeys: new Set(),
+        affectedDocumentIds: new Set()
+      },
+      {
+        type: 'interactive-media',
+        getArraysToFix: content => [content.chapters],
+        affectedSectionKeys: new Set(),
+        affectedDocumentIds: new Set()
+      },
+      {
+        type: 'media-analysis',
+        getArraysToFix: content => [content.tracks, content.chapters],
+        affectedSectionKeys: new Set(),
+        affectedDocumentIds: new Set()
+      },
+      {
+        type: 'media-slideshow',
+        getArraysToFix: content => [content.chapters],
+        affectedSectionKeys: new Set(),
+        affectedDocumentIds: new Set()
+      },
+      {
+        type: 'multitrack-media',
+        getArraysToFix: content => [content.tracks],
+        affectedSectionKeys: new Set(),
+        affectedDocumentIds: new Set()
+      },
+      {
+        type: 'quick-tester',
+        getArraysToFix: content => [content.tests],
+        affectedSectionKeys: new Set(),
+        affectedDocumentIds: new Set()
+      },
+      {
+        type: 'select-field',
+        getArraysToFix: content => [content.items],
+        affectedSectionKeys: new Set(),
+        affectedDocumentIds: new Set()
+      }
+    ];
+
+    const affectedSectionTypes = sectionsToFix.map(stf => stf.type);
+    const cursor = this.db.collection(collectionName).find({ 'sections.type': { $in: affectedSectionTypes } });
+
+    while (await cursor.hasNext()) {
+      const doc = await cursor.next();
+
+      for (const section of doc.sections.filter(s => !!s.content)) {
+        const fixInfo = sectionsToFix.find(stf => stf.type === section.type);
+        if (fixInfo) {
+          const arraysToFix = fixInfo.getArraysToFix(section.content);
+          for (const arrayToFix of arraysToFix) {
+            if (this.fixUniqueKeysInArray(arrayToFix)) {
+              fixInfo.affectedDocumentIds.add(doc._id);
+              fixInfo.affectedSectionKeys.add(section.key);
+            }
+          }
+        }
+      }
+
+      if (sectionsToFix.some(stf => stf.affectedDocumentIds.has(doc._id))) {
+        await this.db.collection(collectionName).replaceOne({ _id: doc._id }, doc);
+      }
+    }
+
+    const totalMigratedDocumentCount = new Set(sectionsToFix.flatMap(stf => [...stf.affectedDocumentIds])).size;
+    console.log(`Migrated ${totalMigratedDocumentCount} documents in collection '${collectionName}'`);
+    for (const stf of sectionsToFix) {
+      console.log(`  * ${stf.affectedSectionKeys.size} '${stf.type}' sections in ${stf.affectedDocumentIds.size} documents`);
+    }
+  }
+
+  async up() {
+    await this.collectionUp('documents');
+    await this.collectionUp('documentRevisions');
+  }
+
+  down() {
+    throw Error('Not supported');
+  }
+}

--- a/src/plugins/catalog/catalog-utils.js
+++ b/src/plugins/catalog/catalog-utils.js
@@ -57,7 +57,7 @@ export function validateContent(content) {
         documentId: joi.string().allow(null).required(),
         description: joi.string().allow('').max(maxDocumentCommentTextLength).required()
       }).required()
-    })).required(),
+    })).unique('key').required(),
     imageTilesConfig: joi.object({
       maxTilesPerRow: joi.number().min(1).required(),
       hoverEffect: joi.string().valid(...Object.values(TILES_HOVER_EFFECT)).required()

--- a/src/plugins/ear-training/ear-training-info.js
+++ b/src/plugins/ear-training/ear-training-info.js
@@ -104,7 +104,7 @@ class EarTrainingInfo {
         abcMidiSound: joi.object({
           initialVolume: joi.number().min(0).max(1).required()
         }).required()
-      })).required(),
+      })).unique('key').required(),
       testsOrder: joi.string().valid(...Object.values(TESTS_ORDER)).required()
     });
 

--- a/src/plugins/interactive-media/interactive-media-info.js
+++ b/src/plugins/interactive-media/interactive-media-info.js
@@ -75,7 +75,7 @@ class InteractiveMediaInfo {
         text: joi.string().allow('').required(),
         answers: joi.array().items(joi.string().allow('')).required(),
         correctAnswerIndex: joi.number().min(-1).required()
-      })).required(),
+      })).unique('key').required(),
       posterImage: joi.object({
         sourceUrl: joi.string().allow('').required()
       }).required()

--- a/src/plugins/media-analysis/media-analysis-utils.js
+++ b/src/plugins/media-analysis/media-analysis-utils.js
@@ -103,12 +103,12 @@ export function validateContent(content) {
       sourceUrl: joi.string().allow('').required(),
       copyrightNotice: joi.string().allow('').required(),
       playbackRange: joi.array().items(joi.number().min(0).max(1)).required()
-    })).min(1).required(),
+    })).unique('key').min(1).required(),
     volumePresets: joi.array().items(joi.object({
       name: joi.string().required(),
       tracks: joi.array().items(joi.number().min(0).max(1)).min(1).required()
     })).min(1).required(),
-    chapters: joi.array().items(chapterSchema).required(),
+    chapters: joi.array().items(chapterSchema).unique('key').required(),
     showVideo: joi.boolean().required(),
     aspectRatio: joi.string().valid(...Object.values(MEDIA_ASPECT_RATIO)).required(),
     posterImage: joi.object({

--- a/src/plugins/media-slideshow/media-slideshow-info.js
+++ b/src/plugins/media-slideshow/media-slideshow-info.js
@@ -78,7 +78,7 @@ class MediaSlideshowInfo {
           copyrightNotice: joi.string().allow('').required()
         }).required(),
         text: joi.string().allow('').required()
-      })).required()
+      })).unique('key').required()
     });
 
     joi.attempt(content, schema, { abortEarly: false, convert: false, noDefaults: true });

--- a/src/plugins/multitrack-media/multitrack-media-utils.js
+++ b/src/plugins/multitrack-media/multitrack-media-utils.js
@@ -40,7 +40,7 @@ export function validateContent(content) {
       sourceUrl: joi.string().allow('').required(),
       copyrightNotice: joi.string().allow('').required(),
       playbackRange: joi.array().items(joi.number().min(0).max(1)).required()
-    })).min(1).required(),
+    })).unique('key').min(1).required(),
     volumePresets: joi.array().items(joi.object({
       name: joi.string().required(),
       tracks: joi.array().items(joi.number().min(0).max(1)).min(1).required()

--- a/src/plugins/quick-tester/quick-tester-info.js
+++ b/src/plugins/quick-tester/quick-tester-info.js
@@ -57,7 +57,7 @@ class QuickTesterInfo {
         key: joi.string().required(),
         question: joi.string().allow('').required(),
         answer: joi.string().allow('').required()
-      })).required(),
+      })).unique('key').required(),
       testsOrder: joi.string().valid(...Object.values(TESTS_ORDER)).required()
     });
 

--- a/src/plugins/select-field/select-field-utils.js
+++ b/src/plugins/select-field/select-field-utils.js
@@ -29,7 +29,7 @@ export function validateContent(content) {
     items: joi.array().items(joi.object({
       key: joi.string().required(),
       text: joi.string().allow('').required()
-    })).required()
+    })).unique('key').required()
   });
 
   joi.attempt(content, schema, { abortEarly: false, convert: false, noDefaults: true });


### PR DESCRIPTION
Closes https://educandu.atlassian.net/browse/EDU-1432

With a copy of production data (from October 2023) the following sections were fixed:

~~~
Migrated 425 documents in collection 'documents'
  * 512 'catalog' sections in 403 documents
  * 16 'ear-training' sections in 10 documents
  * 0 'interactive-media' sections in 0 documents
  * 0 'media-analysis' sections in 0 documents
  * 0 'media-slideshow' sections in 0 documents
  * 0 'multitrack-media' sections in 0 documents
  * 20 'quick-tester' sections in 19 documents
  * 0 'select-field' sections in 0 documents
Migrated 5597 documents in collection 'documentRevisions'
  * 594 'catalog' sections in 5249 documents
  * 18 'ear-training' sections in 216 documents
  * 0 'interactive-media' sections in 0 documents
  * 0 'media-analysis' sections in 0 documents
  * 0 'media-slideshow' sections in 0 documents
  * 0 'multitrack-media' sections in 0 documents
  * 23 'quick-tester' sections in 219 documents
  * 0 'select-field' sections in 0 documents
~~~

With the current UI I cannot reproduce creating items with duplicate keys, so it seems the corrupt data comes from an earlier version or migration script (which might explain why it only occurs in plugin types that exist for a long time, `catalog` being the former `image-tiles` plugin).