### PR TITLE
EDU-1541 Create fake document requests for testing

### DIFF
--- a/migrations/educandu-2024-04-15-01-reset-documentRequests-collection.js
+++ b/migrations/educandu-2024-04-15-01-reset-documentRequests-collection.js
@@ -1,0 +1,21 @@
+export default class Educandu_2024_04_15_01_reset_documentRequests_collection {
+  constructor(db) {
+    this.db = db;
+  }
+
+  async up() {
+    await this.db.dropCollection('documentRequests');
+    await this.db.createCollection('documentRequests');
+  }
+
+  async down() {
+    await this.db.dropCollection('documentRequests');
+    await this.db.createCollection('documentRequests');
+    await this.db.collection('documentRequests').createIndexes([
+      {
+        name: '_idx_documentId_registeredOn_registeredOnDayOfWeek_type_isUserLoggedIn',
+        key: { documentId: 1, registeredOn: 1, registeredOnDayOfWeek: 1, type: 1, isUserLoggedIn: 1 }
+      }
+    ]);
+  }
+}

--- a/src/components/pages/tests.js
+++ b/src/components/pages/tests.js
@@ -1,6 +1,7 @@
 /* eslint-disable no-console */
 
 import by from 'thenby';
+import axios from 'axios';
 import PropTypes from 'prop-types';
 import UrlInput from '../url-input.js';
 import TagSelect from '../tag-select.js';
@@ -58,6 +59,17 @@ function Tests({ PageTemplate, initialState }) {
   const handleCopyToClipboard = async clipboardText => {
     await window.navigator.clipboard.writeText(clipboardText);
     message.success('Copied to clipboard');
+  };
+
+  // DocumentRequests
+  const [documentRequestsYear, setDocumentRequestsYear] = useState('2023');
+  const handleDocumentRequestsGoClick = () => {
+    const postUrl = `/api/v1/tests/create-document-requests/${encodeURIComponent(documentRequestsYear)}`;
+    axios.post(postUrl).catch(error => {
+      console.error(error);
+    });
+    // eslint-disable-next-line no-alert
+    window.alert('Started DocumentRequests creation, check your console!');
   };
 
   // StarRating
@@ -255,6 +267,23 @@ function Tests({ PageTemplate, initialState }) {
             onChange={handleTabChange}
             destroyInactiveTabPane
             items={[
+              {
+                key: 'DocumentRequests',
+                label: 'DocumentRequests',
+                children: (
+                  <div>
+                    Create 10.000 document requests per day in year:
+                    &nbsp;
+                    <Input
+                      style={{ width: '100px' }}
+                      value={documentRequestsYear}
+                      onChange={event => setDocumentRequestsYear(event.target.value)}
+                      />
+                    &nbsp;&nbsp;&nbsp;
+                    <Button type="primary" onClick={handleDocumentRequestsGoClick}>GO!</Button>
+                  </div>
+                )
+              },
               {
                 key: 'StarRating',
                 label: 'StarRating',

--- a/src/domain/schemas/document-request-schemas.js
+++ b/src/domain/schemas/document-request-schemas.js
@@ -1,9 +1,10 @@
 import joi from 'joi';
+import { ObjectId } from 'mongodb';
 import { DAY_OF_WEEK } from '../constants.js';
 import { idOrKeySchema } from './shared-schemas.js';
 
 export const documentRequestDBSchema = joi.object({
-  _id: idOrKeySchema.required(),
+  _id: joi.object().instance(ObjectId).required(),
   documentId: idOrKeySchema.required(),
   documentRevisionId: idOrKeySchema.required(),
   isWriteRequest: joi.boolean().required(),

--- a/src/server/tests-controller.js
+++ b/src/server/tests-controller.js
@@ -1,19 +1,24 @@
+import moment from 'moment';
+import Database from '../stores/database.js';
+import uniqueId from '../utils/unique-id.js';
 import PageRenderer from './page-renderer.js';
 import permissions from '../domain/permissions.js';
 import { PAGE_NAME } from '../domain/page-name.js';
 import RoomService from '../services/room-service.js';
+import { getDayOfWeek } from '../utils/date-utils.js';
 import DocumentService from '../services/document-service.js';
 import needsPermission from '../domain/needs-permission-middleware.js';
 import ClientDataMappingService from '../services/client-data-mapping-service.js';
 
 class TestsController {
-  static dependencies = [PageRenderer, DocumentService, RoomService, ClientDataMappingService];
+  static dependencies = [PageRenderer, DocumentService, RoomService, ClientDataMappingService, Database];
 
-  constructor(pageRenderer, documentService, roomService, clientDataMappingService) {
+  constructor(pageRenderer, documentService, roomService, clientDataMappingService, database) {
     this.pageRenderer = pageRenderer;
     this.documentService = documentService;
     this.roomService = roomService;
     this.clientDataMappingService = clientDataMappingService;
+    this.database = database;
   }
 
   async handleGetTestsPage(req, res) {
@@ -41,11 +46,65 @@ class TestsController {
     return this.pageRenderer.sendPage(req, res, PAGE_NAME.tests, initialState);
   }
 
+  async handlePostCreateDocumentRequests(req, res) {
+    const year = Number.parseInt(req.params.year, 10);
+    await this.createTestDocumentRequests(year);
+    return res.send({});
+  }
+
+  /* eslint-disable no-unreachable, no-console, no-promise-executor-return */
+  async createTestDocumentRequests(year) {
+    const getRandomInt = (min, max) => Math.floor(Math.random() * (max - min + 1) + min);
+
+    const ENTRIES_PER_DAY = 10000;
+    const TEN_HOURS_IN_MS = 10 * 60 * 60 * 1000;
+
+    const documents = await this.database.documents.find({ roomContext: null }, { projection: { _id: 1, revision: 1 } }).toArray();
+
+    let dayCounter = 1;
+    let eightOClock = moment({ year, hour: 8 });
+    while (eightOClock.year() === year) {
+      console.log(`[DAY ${dayCounter}]: ${eightOClock.format('L')}`);
+
+      const recordsToInsert = [];
+
+      for (let i = 0; i < ENTRIES_PER_DAY; i += 1) {
+        const offset = getRandomInt(0, TEN_HOURS_IN_MS);
+        const document = documents[getRandomInt(0, documents.length - 1)];
+        const registeredOn = moment(eightOClock).add(offset, 'milliseconds').toDate();
+        const registeredOnDayOfWeek = getDayOfWeek(registeredOn);
+        recordsToInsert.push({
+          _id: uniqueId.create(),
+          documentId: document._id,
+          documentRevisionId: document.revision,
+          isWriteRequest: getRandomInt(0, 5) === 5,
+          isLoggedInRequest: getRandomInt(0, 3) !== 3,
+          registeredOn,
+          registeredOnDayOfWeek
+        });
+      }
+
+      await this.database.documentRequests.insertMany(recordsToInsert);
+
+      eightOClock = moment(eightOClock).add(1, 'day');
+      dayCounter += 1;
+    }
+  }
+  /* eslint-enable no-unreachable, no-console, no-promise-executor-return */
+
   registerPages(router) {
     router.get(
       '/tests',
       needsPermission(permissions.MANAGE_SETUP),
       (req, res) => this.handleGetTestsPage(req, res)
+    );
+  }
+
+  registerApi(router) {
+    router.post(
+      '/api/v1/tests/create-document-requests/:year',
+      needsPermission(permissions.MANAGE_SETUP),
+      (req, res) => this.handlePostCreateDocumentRequests(req, res)
     );
   }
 }

--- a/src/server/tests-controller.js
+++ b/src/server/tests-controller.js
@@ -1,6 +1,6 @@
 import moment from 'moment';
+import { ObjectId } from 'mongodb';
 import Database from '../stores/database.js';
-import uniqueId from '../utils/unique-id.js';
 import PageRenderer from './page-renderer.js';
 import permissions from '../domain/permissions.js';
 import { PAGE_NAME } from '../domain/page-name.js';
@@ -74,7 +74,7 @@ class TestsController {
         const registeredOn = moment(eightOClock).add(offset, 'milliseconds').toDate();
         const registeredOnDayOfWeek = getDayOfWeek(registeredOn);
         recordsToInsert.push({
-          _id: uniqueId.create(),
+          _id: new ObjectId(),
           documentId: document._id,
           documentRevisionId: document.revision,
           isWriteRequest: getRandomInt(0, 5) === 5,

--- a/src/services/document-request-service.js
+++ b/src/services/document-request-service.js
@@ -1,4 +1,4 @@
-import uniqueId from '../utils/unique-id.js';
+import { ObjectId } from 'mongodb';
 import { getDayOfWeek } from '../utils/date-utils.js';
 import DocumentRequestStore from '../stores/document-request-store.js';
 
@@ -21,7 +21,7 @@ class DocumentRequestService {
     }
 
     const newDocumentRequest = {
-      _id: uniqueId.create(),
+      _id: new ObjectId(),
       documentId: document._id,
       documentRevisionId: document.revision,
       isWriteRequest,
@@ -51,7 +51,7 @@ class DocumentRequestService {
     }
 
     const newDocumentRequest = {
-      _id: uniqueId.create(),
+      _id: new ObjectId(),
       documentId: documentRevision.documentId,
       documentRevisionId: documentRevision._id,
       isWriteRequest: false,

--- a/src/services/document-request-service.spec.js
+++ b/src/services/document-request-service.spec.js
@@ -1,3 +1,4 @@
+import { ObjectId } from 'mongodb';
 import { createSandbox } from 'sinon';
 import Database from '../stores/database.js';
 import { DAY_OF_WEEK } from '../domain/constants.js';
@@ -62,7 +63,7 @@ describe('document-request-service', () => {
 
         it('should create a document request', () => {
           expect(result).toEqual({
-            _id: expect.stringMatching(/\w+/),
+            _id: expect.any(ObjectId),
             documentId: document._id,
             documentRevisionId: document.revision,
             registeredOn: now,
@@ -86,7 +87,7 @@ describe('document-request-service', () => {
 
         it('should create a document request', () => {
           expect(result).toEqual({
-            _id: expect.stringMatching(/\w+/),
+            _id: expect.any(ObjectId),
             documentId: document._id,
             documentRevisionId: document.revision,
             registeredOn: now,
@@ -127,7 +128,7 @@ describe('document-request-service', () => {
 
         it('should create a document request', () => {
           expect(result).toEqual({
-            _id: expect.stringMatching(/\w+/),
+            _id: expect.any(ObjectId),
             documentId: document._id,
             documentRevisionId: document.revision,
             registeredOn: now,
@@ -151,7 +152,7 @@ describe('document-request-service', () => {
 
         it('should create a document request', () => {
           expect(result).toEqual({
-            _id: expect.stringMatching(/\w+/),
+            _id: expect.any(ObjectId),
             documentId: document._id,
             documentRevisionId: document.revision,
             registeredOn: now,
@@ -194,7 +195,7 @@ describe('document-request-service', () => {
 
         it('should create a document request', () => {
           expect(result).toEqual({
-            _id: expect.stringMatching(/\w+/),
+            _id: expect.any(ObjectId),
             documentId: documentRevision.documentId,
             documentRevisionId: documentRevision._id,
             registeredOn: now,
@@ -219,7 +220,7 @@ describe('document-request-service', () => {
 
         it('should create a document request', () => {
           expect(result).toEqual({
-            _id: expect.stringMatching(/\w+/),
+            _id: expect.any(ObjectId),
             documentId: documentRevision.documentId,
             documentRevisionId: documentRevision._id,
             registeredOn: now,

--- a/src/stores/collection-specs/document-requests.js
+++ b/src/stores/collection-specs/document-requests.js
@@ -1,9 +1,4 @@
 export default {
   name: 'documentRequests',
-  indexes: [
-    {
-      name: '_idx_documentId_registeredOn_registeredOnDayOfWeek_isWriteRequest_isLoggedInRequest',
-      key: { documentId: 1, registeredOn: 1, registeredOnDayOfWeek: 1, isWriteRequest: 1, isLoggedInRequest: 1 }
-    }
-  ]
+  indexes: []
 };


### PR DESCRIPTION
There are two optimizations regarding space consumption according to the findings described in the ticket:
1. Switching the `_id` field data type from `string` to `ObjectId`
2. Removing the compound index

There is also a new tab on the tests page to create 10.000 entries for one year for testing purposes.

Closes https://educandu.atlassian.net/browse/EDU-1541