### PR TITLE
EDU-1575 Fix rating position on document page

### DIFF
--- a/src/components/pages/document.less
+++ b/src/components/pages/document.less
@@ -19,12 +19,15 @@
 }
 
 .DocumentPage-documentCategoryLinks {
-  grid-row: 1;
-  grid-column: 1;
   gap: 10px;
   display: flex;
   flex-wrap: wrap;
   justify-content: flex-start;
+}
+
+.DocumentPage-documentRating {
+  grid-row: 1;
+  grid-column: 2;
 }
 
 .DocumentPage-documentCategoryLink {


### PR DESCRIPTION
Closes https://educandu.atlassian.net/browse/EDU-1575

I tried both positioning orders (left <-> right):
 
**Desktop**
<img width="882" alt="Screenshot 2024-05-09 at 12 24 20" src="https://github.com/educandu/educandu/assets/8189923/c8488ffe-92d7-4782-be06-2c5ef9cade80">
<img width="883" alt="Screenshot 2024-05-09 at 12 22 42" src="https://github.com/educandu/educandu/assets/8189923/2cda0a96-ad92-4efe-8925-75c397bcc5a0">


**Mobile**
<img width="371" alt="Screenshot 2024-05-09 at 12 36 12" src="https://github.com/educandu/educandu/assets/8189923/8ca9d1c9-ee91-405a-aca7-5776e0da839b">
<img width="373" alt="Screenshot 2024-05-09 at 12 22 24" src="https://github.com/educandu/educandu/assets/8189923/b068436e-39ca-439a-b235-8b0fe4d42dd9">


I went with the "categories then rating" order because it looks ok on mobile out of the box, with keeping the page padding (so that the rating element is right aligned with the page content). Otherwise we would need to introduce more spacing on the right (which you break right side alignment) or push the page content lower.

Does this sound alright?